### PR TITLE
Remove LD_PRELOAD shell environment variable

### DIFF
--- a/main/enigma.cpp
+++ b/main/enigma.cpp
@@ -232,6 +232,9 @@ int main(int argc, char **argv)
 	atexit(object_dump);
 #endif
 
+	// Clear LD_PRELOAD so that shells and processes launched by Enigma2 can pass on file handles and pipes
+	unsetenv("LD_PRELOAD");
+
 	gst_init(&argc, &argv);
 
 	// set pythonpath if unset


### PR DESCRIPTION
This change removes the LD_PRELOAD shell environment variable from any subsequent shells launched by Enigma2. This allows shells and programs run from those shells to create pipes and pass file handles between processes.

This change is better than the previous fix applied to mytest.py as there is a potential memory leak when using os.environ in Python.
