### PR TITLE
 Refactor VirtualKeyBoard

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -64,6 +64,64 @@
 		<key id="KEY_VIDEO" mapto="file" flags="m"/>
 	</map>
 
+	<map context="VirtualKeyBoardActions">
+		<key id="KEY_RED" mapto="cancel" flags="m" />
+		<key id="KEY_GREEN" mapto="save" flags="m" />
+		<key id="KEY_YELLOW" mapto="locale" flags="m" />
+		<key id="KEY_BLUE" mapto="shift" flags="m" />
+		<key id="KEY_EXIT" mapto="cancel" flags="m" />
+		<key id="KEY_OK" mapto="ok" flags="m" />
+		<key id="KEY_UP" mapto="up" flags="mr" />
+		<key id="KEY_PREVIOUS" mapto="first" flags="m" />
+		<key id="KEY_REWIND" mapto="prev" flags="mr" />
+		<key id="KEY_LEFT" mapto="left" flags="mr" />
+		<key id="KEY_RIGHT" mapto="right" flags="mr" />
+		<key id="KEY_FASTFORWARD" mapto="next" flags="mr" />
+		<key id="KEY_NEXT" mapto="last" flags="m" />
+		<key id="KEY_DOWN" mapto="down" flags="mr" />
+		<key id="KEY_LAST" mapto="backspace" flags="mr" />
+		<key id="KEY_STOP" mapto="backspace" flags="mr" />
+		<key id="KEY_PLAYPAUSE" mapto="delete" flags="mr" />
+		<key id="KEY_INFO" mapto="toggleOverwrite" flags="m" />
+		<key id="KEY_0" mapto="0" flags="m" />
+		<key id="KEY_1" mapto="1" flags="m" />
+		<key id="KEY_2" mapto="2" flags="m" />
+		<key id="KEY_3" mapto="3" flags="m" />
+		<key id="KEY_4" mapto="4" flags="m" />
+		<key id="KEY_5" mapto="5" flags="m" />
+		<key id="KEY_6" mapto="6" flags="m" />
+		<key id="KEY_7" mapto="7" flags="m" />
+		<key id="KEY_8" mapto="8" flags="m" />
+		<key id="KEY_9" mapto="9" flags="m" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_F1" mapto="cancel" flags="m" />
+		<key id="KEY_F2" mapto="save" flags="m" />
+		<key id="KEY_F3" mapto="locale" flags="m" />
+		<key id="KEY_F4" mapto="shift" flags="m" />
+		<key id="KEY_ESC" mapto="cancel" flags="m" />
+		<key id="KEY_ENTER" mapto="ok" flags="m" />
+		<key id="KEY_PREVIOUSSONG" mapto="first" flags="m" />
+		<key id="KEY_F9" mapto="first" flags="m" />
+		<key id="KEY_F11" mapto="prev" flags="m" />
+		<key id="KEY_F12" mapto="next" flags="m" />
+		<key id="KEY_NEXTSONG" mapto="last" flags="m" />
+		<key id="KEY_F10" mapto="last" flags="m" />
+		<key id="KEY_BACKSPACE" mapto="backspace" flags="mr" />
+		<key id="KEY_DELETE" mapto="delete" flags="mr" />
+		<key id="KEY_INSERT" mapto="toggleOverwrite" flags="m" />
+		<key id="KEY_ASCII" mapto="gotAsciiCode" flags="mr" />
+		<key id="KEY_KP0" mapto="0" flags="m" />
+		<key id="KEY_KP1" mapto="1" flags="m" />
+		<key id="KEY_KP2" mapto="2" flags="m" />
+		<key id="KEY_KP3" mapto="3" flags="m" />
+		<key id="KEY_KP4" mapto="4" flags="m" />
+		<key id="KEY_KP5" mapto="5" flags="m" />
+		<key id="KEY_KP6" mapto="6" flags="m" />
+		<key id="KEY_KP7" mapto="7" flags="m" />
+		<key id="KEY_KP8" mapto="8" flags="m" />
+		<key id="KEY_KP9" mapto="9" flags="m" />
+	</map>
+
 	<map context="InputActions">
 		<key id="KEY_LEFT" mapto="left" flags="mr"/>
 		<key id="KEY_RIGHT" mapto="right" flags="mr"/>

--- a/doc/VIRTUALKEYBOARD
+++ b/doc/VIRTUALKEYBOARD
@@ -1,0 +1,133 @@
+A Guide to the VirtualKeyBoard Screen
+-------------------------------------
+
+Written by IanSav - 15-Aug-2018
+
+This document explains the changes and updates to the VirtualKeyBoard of 
+Enigma2.  The code is located in:
+	/usr/lib/enigma2/python/Screens/VirtualKeyBoard.py
+
+The revised virtual keyboard is dynamically created based on the data 
+defined in the "self.locales" data in the "__init__" method of the 
+"VirtualKeyBoard" class.  To make creating new locales based on common 
+languages easier a number of base language definitions are provided. 
+(Currently English, French, German, Russian, Scandinavian and Spanish.) 
+The locales are based on the list at https://lh.2xlibre.net/locales/.
+
+The maximum width of the keyboard has been set at 14 buttons.  This 
+limitation is set by the skin allocation of space for the keyboard and then 
+confirmed in this code in the "virtualKeyBoardEntryComponent" method.  If 
+the "keyList" data describes a keyboard less than 14 characters then that 
+keyboard will be centred in the 14 wide keyboard space.
+
+Each element of the "keyList" data is a button displayed on the virtual 
+keyboard.  Certain button names are mapped to images that will be used 
+for that button.  The current image button definitions are listed in 
+the "self.keyImages" dictionary in the "__init__" method of the 
+"VirtualKeyBoard" class. To make future updates easier all non English 
+characters are represented by their unicode numeric code 
+(https://en.wikipedia.org/wiki/List_of_Unicode_characters).
+
+This revision also allows the four colour buttons to be assigned to any 
+keyboard key by nominating the key text in the "self.keyBackgrounds" 
+dictionary in the "__init__" method of the "VirtualKeyBoard" class. 
+This change will allow for colour button text to be localised rather than 
+depending on a graphical button to achieve the coloured border.  Note that 
+the ENTER and SHIFT button graphics include the default GREEN and BLUE 
+borders, respectively, as a default.
+
+This revision also adds the ability to define the foreground colours of the 
+characters on the virtual keyboard.  The colour selections for the unshifted 
+and three predefined shift levels are defined as white, white, cyan and 
+magenta respectively.  These colours match the default SHIFT button 
+images.  These colours can be overridden by a skin author via the 
+"VirtualKeyBoardShiftColors" skin parameter.  (The number of shift levels 
+can be increased if required.)
+
+This revision also improves font size options.  The previous 
+"VirtualKeyBoard" skin font parameter is retained but a new scaling option 
+has been added to the code such that short text messages can be now assigned 
+to keyboard buttons.  For example, for the en_AU implementation spare keys 
+have been assigned to text like ".com", ".org" etc to make Internet address 
+entry easier.  To ensure that longer key text can fit in the screen space 
+available any text longer than one character will be drawn at 56% of the 
+"VirtualKeyBoard" skin font parameter assigned font size.
+
+This revision also adds HELP button text to assist users with using the 
+updated Virtual KeyBoard interface.
+
+If the VirtualKeyBoard interface is to be re-skinned then the following
+"name=" screen widgets should be defined:
+	prompt   - This widget displays the prompt text for the entry.
+	text     - This widget displays the current text buffer.
+	list     - This widget displays the keyboard grid.
+	locale   - This widget displays the currently selected keyboard
+		   language.
+	language - This widget displays the current language.
+
+The standard colour and action buttons "source=" screen widgets can also 
+be defined:
+	key_red    - This widget displays the RED button exit text prompt.
+	key_green  - This widget displays the GREEN button save text prompt.
+	key_yellow - This widget displays the YELLOW button locale menu
+		     prompt.
+	key_blue   - This widget displays the BLUE button shift text prompt.
+	key_info   - This widget triggers the INFO button.
+	key_help   - This widget triggers the HELP button.
+
+	(See /doc/BUTTONGUIDE in the repository for more information.)
+
+For example in a 1280 x 720 skin:
+	<fonts>
+		<font name="DejaVuSans" filename="DejaVuSans.ttf" scale="100" />
+		<alias name="VirtualKeyBoard" font="DejaVuSans" size="28" height="45" />
+	</fonts>
+
+	<parameters>
+		<parameter name="VirtualKeyBoard" value="45,45" />
+		<parameter name="VirtualKeyBoardShiftColors" value="0x00ffffff,0x00ffffff,0x0000ffff,0x00ff00ff" />
+	</parameters>
+
+	<screen name="VirtualKeyBoard" title="Virtual Keyboard" position="center,center" size="660,375" zPosition="99">
+		<widget name="prompt" position="15,10" size="630,25" font="Regular;20" noWrap="1" transparent="1" />
+		<ePixmap pixmap="buttons/vkey_text.png" position="10,35" size="640,50" alphatest="blend" zPosition="-4" />
+		<widget name="text" position="15,35" size="630,46" font="Regular;40" halign="right" noWrap="1" transparent="1" />
+		<widget name="list" position="15,100" size="630,225" backgroundColor="#001c2c5c" foregroundColor="window-fg" selectionDisabled="1" transparent="1" />
+		<widget name="locale" position="15,340" size="570,25" font="Regular;20" transparent="1" />
+		<widget name="mode" position="585,340" size="60,25" font="Regular;20" halign="right" transparent="1" valign="center" />
+		<widget name="language" position="0,0" size="0,0" font="Regular;20" transparent="1" />
+	</screen>
+
+For example in a 1920 x 1080 skin:
+	<fonts>
+		<font name="DejaVuSans" filename="DejaVuSans.ttf" scale="100" />
+		<alias name="VirtualKeyBoard" font="DejaVuSans" size="42" height="68" />
+	</fonts>
+
+	<parameters>
+		<parameter name="VirtualKeyBoard" value="68,68" />
+		<parameter name="VirtualKeyBoardShiftColors" value="0x00ffffff,0x00ffffff,0x0000ffff,0x00ff00ff" />
+	</parameters>
+
+	<screen name="VirtualKeyBoard" title="Virtual Keyboard" position="center,center" size="980,495" zPosition="99">
+		<widget name="prompt" position="14,10" size="952,25" font="Regular;20" noWrap="1" transparent="1" />
+		<ePixmap pixmap="buttons/vkey_text.png" position="10,45" size="960,50" alphatest="blend" zPosition="-4" />
+		<widget name="text" position="14,48" size="952,46" font="Regular;40" halign="right" noWrap="1" transparent="1" />
+		<widget name="list" position="14,105" size="952,340" backgroundColor="#001c2c5c" foregroundColor="window-fg" selectionDisabled="1" transparent="1" />
+		<widget name="locale" position="14,460" size="800,25" font="Regular;20" transparent="1" />
+		<widget name="mode" position="892,460" size="60,25" font="Regular;20" halign="right" transparent="1" valign="center" />
+		<widget name="language" position="0,0" size="0,0" font="Regular;20" transparent="1" />
+	</screen>
+
+NOTE:
+	The most important changes for a skin is to ensure that the width of 
+	the "list" object is wide enough to display the larger keyboard.  The 
+	width is calculated by multiplying number of buttons (14) by the 
+	width of each button (in parameter "VirtualKeyBoard" and the actual 
+	width of the button background or image. (14 x 45 = 630) 
+	Also, the enhanced VirtualKeyBoard adds some new button images and 
+	abandons others.  Graphic buttons for plain text are deprecated as 
+	the new code creates these on the fly while allowing for language 
+	localisation.
+
+---END---

--- a/lib/python/Screens/VirtualKeyBoard.py
+++ b/lib/python/Screens/VirtualKeyBoard.py
@@ -1,348 +1,827 @@
-# -*- coding: UTF-8 -*-
-from enigma import eListboxPythonMultiContent, gFont, RT_HALIGN_CENTER, RT_VALIGN_CENTER, getPrevAsciiCode
-from Screens.Screen import Screen
-from Components.Language import language
-from Components.ActionMap import NumberActionMap
-from Components.Sources.StaticText import StaticText
+import copy
+import skin
+
+from enigma import eListboxPythonMultiContent, gFont, getPrevAsciiCode, RT_HALIGN_CENTER, RT_VALIGN_CENTER
+
+from Components.ActionMap import HelpableNumberActionMap
 from Components.Input import Input
 from Components.Label import Label
+from Components.Language import language
 from Components.MenuList import MenuList
-from Components.MultiContent import MultiContentEntryText, MultiContentEntryPixmapAlphaTest, MultiContentEntryPixmapAlphaBlend
-from Tools.Directories import resolveFilename, SCOPE_ACTIVE_SKIN
+from Components.MultiContent import MultiContentEntryText, MultiContentEntryPixmapAlphaBlend
+from Components.Sources.StaticText import StaticText
+from Screens.ChoiceBox import ChoiceBox
+from Screens.HelpMenu import HelpableScreen
+from Screens.Screen import Screen
+from Tools.Directories import resolveFilename, SCOPE_CURRENT_SKIN
 from Tools.LoadPixmap import LoadPixmap
 from Tools.NumericalTextInput import NumericalTextInput
-import skin
+
 
 class VirtualKeyBoardList(MenuList):
 	def __init__(self, list, enableWrapAround=False):
 		MenuList.__init__(self, list, enableWrapAround, eListboxPythonMultiContent)
-		font = skin.fonts.get("VirtualKeyboard", ("Regular", 28, 45))
+		font = skin.fonts.get("VirtualKeyBoard", ("Regular", 28, 45))
 		self.l.setFont(0, gFont(font[0], font[1]))
+		self.l.setFont(1, gFont(font[0], font[1] * 5 / 9))  # Smaller font is 56% the height of bigger font
 		self.l.setItemHeight(font[2])
+
 
 class VirtualKeyBoardEntryComponent:
 	def __init__(self):
 		pass
 
-class VirtualKeyBoard(Screen):
-	def __init__(self, session, title="", **kwargs):
+
+# The revised virtual keyboard is dynamically created based on the data
+# defined in the "self.locales" data in the "__init__" method of the
+# "VirtualKeyBoard" class.  To make creating new locales based on common
+# languages easier a number of base language definitions are provided.
+# (Currently English, French, German, Russian, Scandinavian and Spanish.)
+# The locales are based on the list at https://lh.2xlibre.net/locales/.
+#
+# The maximum width of the keyboard has been set at 14 buttons.  This
+# limitation is set by the skin allocation of space for the keyboard and then
+# confirmed in this code in the "virtualKeyBoardEntryComponent" method.  If
+# the "keyList" data describes a keyboard less than 14 characters then that
+# keyboard will be centred in the 14 button wide keyboard space.
+#
+# Each element of the "keyList" data is a button displayed on the virtual
+# keyboard.  Certain button names are mapped to images that will be used
+# for that button.  The current image button definitions are listed in
+# the "self.keyImages" dictionary in the "__init__" method of the
+# "VirtualKeyBoard" class. To make future updates easier all non English
+# characters are represented by their unicode numeric code
+# (https://en.wikipedia.org/wiki/List_of_Unicode_characters).
+#
+# This revision also allows the four colour buttons to be assigned to any
+# keyboard key by nominating the key text in the "self.keyBackgrounds"
+# dictionary in the "__init__" method of the "VirtualKeyBoard" class.
+# This change will allow for colour button text to be localised rather than
+# depending on a graphical button to achieve the coloured border.  Note that
+# the ENTER and SHIFT button graphics include the default GREEN and BLUE
+# borders, respectively, as a default.
+#
+# This revision also adds the ability to define the foreground colours of the
+# characters on the virtual keyboard.  The colour selections for the unshifted
+# and three predefined shift levels are defined as white, white, cyan and
+# magenta respectively.  These colours match the default SHIFT button
+# images.  These colours can be overridden by a skin author via the
+# "VirtualKeyBoardShiftColors" skin parameter.  (The number of shift levels
+# can be increased if required.)
+#
+# This revision also improves font size options.  The previous
+# "VirtualKeyBoard" skin font parameter is retained but a new scaling option
+# has been added to the code such that short text messages can be assigned to
+# keyboard buttons.  For example, for the en_AU implementation spare keys
+# have been assigned to text like ".com", ".org" etc to make Internet address
+# entry easier.  To ensure that longer key text can fit in the screen space
+# available any text longer than one character will be drawn at 56% of the
+# "VirtualKeyBoard" skin font parameter assigned font size.
+#
+# This revision also adds HELP button text to assist users with using the
+# updated Virtual KeyBoard interface.
+#
+# If the VirtualKeyBoard interface is to be reskinned then the following
+# "name=" screen widgets should be defined:
+# 	prompt   - This widget displays the prompt text for the entry.
+# 	text     - This widget displays the current text buffer.
+# 	list     - This widget displays the keyboard grid.
+# 	locale   - This widget displays the currently selected keyboard
+# 		   language.
+# 	language - This widget displays the current language.
+#
+# The standard colour and action buttons "source=" screen widgets can also
+# be defined:
+# 	key_red    - This widget displays the RED button exit text prompt.
+# 	key_green  - This widget displays the GREEN button save text prompt.
+# 	key_yellow - This widget displays the YELLOW button locale menu
+# 		     prompt.
+# 	key_blue   - This widget displays the BLUE button shift text prompt.
+# 	key_info   - This widget triggers the INFO button.
+# 	key_help   - This widget triggers the HELP button.
+#
+# 	(See /doc/BUTTONGUIDE in the repository for more information.)
+#
+# For example in a 1280 x 720 skin:
+# 	<fonts>
+# 		<font name="DejaVuSans" filename="DejaVuSans.ttf" scale="100" />
+# 		<alias name="VirtualKeyBoard" font="DejaVuSans" size="28" height="45" />
+# 	</fonts>
+#
+# 	<parameters>
+# 		<parameter name="VirtualKeyBoard" value="45,45" />
+# 		<parameter name="VirtualKeyBoardShiftColors" value="0x00ffffff,0x00ffffff,0x0000ffff,0x00ff00ff" />
+# 	</parameters>
+#
+# 	<screen name="VirtualKeyBoard" title="Virtual Keyboard" position="center,center" size="660,375" zPosition="99">
+# 		<widget name="prompt" position="15,10" size="630,25" font="Regular;20" noWrap="1" transparent="1" />
+# 		<ePixmap pixmap="buttons/vkey_text.png" position="10,35" size="640,50" alphatest="blend" zPosition="-4" />
+# 		<widget name="text" position="15,35" size="630,46" font="Regular;40" halign="right" noWrap="1" transparent="1" />
+# 		<widget name="list" position="15,100" size="630,225" backgroundColor="#001c2c5c" foregroundColor="window-fg" selectionDisabled="1" transparent="1" />
+# 		<widget name="locale" position="15,340" size="570,25" font="Regular;20" transparent="1" />
+# 		<widget name="mode" position="585,340" size="60,25" font="Regular;20" halign="right" transparent="1" valign="center" />
+# 		<widget name="language" position="0,0" size="0,0" font="Regular;20" transparent="1" />
+# 	</screen>
+#
+# For example in a 1920 x 1080 skin:
+# 	<fonts>
+# 		<font name="DejaVuSans" filename="DejaVuSans.ttf" scale="100" />
+# 		<alias name="VirtualKeyBoard" font="DejaVuSans" size="42" height="68" />
+# 	</fonts>
+#
+# 	<parameters>
+# 		<parameter name="VirtualKeyBoard" value="68,68" />
+# 		<parameter name="VirtualKeyBoardShiftColors" value="0x00ffffff,0x00ffffff,0x0000ffff,0x00ff00ff" />
+# 	</parameters>
+#
+# 	<screen name="VirtualKeyBoard" title="Virtual Keyboard" position="center,center" size="980,495" zPosition="99">
+# 		<widget name="prompt" position="14,10" size="952,25" font="Regular;20" noWrap="1" transparent="1" />
+# 		<ePixmap pixmap="buttons/vkey_text.png" position="10,45" size="960,50" alphatest="blend" zPosition="-4" />
+# 		<widget name="text" position="14,48" size="952,46" font="Regular;40" halign="right" noWrap="1" transparent="1" />
+# 		<widget name="list" position="14,105" size="952,340" backgroundColor="#001c2c5c" foregroundColor="window-fg" selectionDisabled="1" transparent="1" />
+# 		<widget name="locale" position="14,460" size="800,25" font="Regular;20" transparent="1" />
+# 		<widget name="mode" position="892,460" size="60,25" font="Regular;20" halign="right" transparent="1" valign="center" />
+# 		<widget name="language" position="0,0" size="0,0" font="Regular;20" transparent="1" />
+# 	</screen>
+#
+# NOTE:
+# 	The most important changes for a skin is to ensure that the width of
+# 	the "list" object is wide enough to display the larger keyboard.  The
+# 	width is calculated by multiplying number of buttons (14) by the
+# 	width of each button (in parameter "VirtualKeyBoard" and the actual
+# 	width of the button background or image. (14 x 45 = 630)
+# 	Also, the enhanced VirtualKeyBoard adds some new button images and
+# 	abandons others.  Graphic buttons for plain text are deprecated as
+# 	the new code creates these on the fly while allowing for language
+# 	localisation.
+#
+class VirtualKeyBoard(Screen, HelpableScreen):
+	def __init__(self, session, title=_("Virtual KeyBoard Text:"), **kwargs):
 		Screen.__init__(self, session)
-		self.setTitle(_(title))
-		self.keys_list = []
-		self.shiftkeys_list = []
+		HelpableScreen.__init__(self)
+		prompt = title  # Title should only be used for screen titles!
+		print "[VirtualKeyBoard] DEBUG:", resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_bg.png")
+		self.key_bg = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_bg.png"))
+		self.key_red_bg = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_red.png"))
+		self.key_green_bg = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_green.png"))
+		self.key_yellow_bg = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_yellow.png"))
+		self.key_blue_bg = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_blue.png"))
+		self.key_sel = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_sel.png"))
+		self.key_backspace = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_backspace.png"))
+		self.key_enter = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_enter.png"))
+		self.key_first = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_first.png"))
+		self.key_last = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_last.png"))
+		self.key_left = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_left.png"))
+		self.key_right = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_right.png"))
+		self.key_shift0 = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_shift0.png"))
+		self.key_shift1 = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_shift1.png"))
+		self.key_shift2 = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_shift2.png"))
+		self.key_shift3 = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_shift3.png"))
+		self.key_space = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_space.png"))
+		self.key_space_alt = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_space_alt.png"))
+		self.keyBackgrounds = {
+			"EXIT": self.key_red_bg,
+			"OK": self.key_green_bg,
+			"SAVE": self.key_green_bg,
+			"LOC": self.key_yellow_bg,
+			"SHFT": self.key_blue_bg
+		}
+		self.keyImages = [{
+			"BACKSPACE": self.key_backspace,
+			"ENTER": self.key_enter,
+			"FIRST": self.key_first,
+			"LAST": self.key_last,
+			"LEFT": self.key_left,
+			"RIGHT": self.key_right,
+			"SHIFT": self.key_shift0,
+			"SPACE": self.key_space_alt
+		}, {
+			"BACKSPACE": self.key_backspace,
+			"ENTER": self.key_enter,
+			"FIRST": self.key_first,
+			"LAST": self.key_last,
+			"LEFT": self.key_left,
+			"RIGHT": self.key_right,
+			"SHIFT": self.key_shift1,
+			"SPACE": self.key_space_alt
+		}, {
+			"BACKSPACE": self.key_backspace,
+			"ENTER": self.key_enter,
+			"FIRST": self.key_first,
+			"LAST": self.key_last,
+			"LEFT": self.key_left,
+			"RIGHT": self.key_right,
+			"SHIFT": self.key_shift2,
+			"SPACE": self.key_space_alt
+		}, {
+			"BACKSPACE": self.key_backspace,
+			"ENTER": self.key_enter,
+			"FIRST": self.key_first,
+			"LAST": self.key_last,
+			"LEFT": self.key_left,
+			"RIGHT": self.key_right,
+			"SHIFT": self.key_shift3,
+			"SPACE": self.key_space_alt
+		}]
+		self.shiftMsgs = [
+			_("Lower case"),
+			_("Upper case"),
+			_("Special 1"),
+			_("Special 2")
+		]
+		self.english = [
+			[
+				[u"`", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"-", u"=", u"BACKSPACE"],
+				[u"FIRST", u"q", u"w", u"e", u"r", u"t", u"y", u"u", u"i", u"o", u"p", u"[", u"]", u"\\"],
+				[u"LAST", u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u";", u"'", u"", u"ENTER"],
+				[u"SHIFT", u"z", u"x", u"c", u"v", u"b", u"n", u"m", u",", u".", u"/", u"", u"", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+			], [
+				[u"~", u"!", u"@", u"#", u"$", u"%", u"^", u"&", u"*", u"(", u")", u"_", u"+", u"BACKSPACE"],
+				[u"FIRST", u"Q", u"W", u"E", u"R", u"T", u"Y", u"U", u"I", u"O", u"P", u"{", u"}", u"|"],
+				[u"LAST", u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u":", u"\"", u"", u"ENTER"],
+				[u"SHIFT", u"Z", u"X", u"C", u"V", u"B", u"N", u"M", u"<", u">", u"?", u"", u"", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+			]
+		]
+		self.french = [
+			[
+				[u"\u00B2", u"&", u"\u00E9", u"\"", u"'", u"(", u"-", u"\u00E8", u"_", u"\u00E7", u"\u00E0", u")", u"=", u"BACKSPACE"],
+				[u"FIRST", u"a", u"z", u"e", u"r", u"t", u"y", u"u", u"i", u"o", u"p", u"$", u"[", u"]"],
+				[u"LAST", u"q", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"m", u"\u00F9", u"*", u"ENTER"],
+				[u"SHIFT", u"<", u"w", u"x", u"c", u"v", u"b", u"n", u",", u";", u":", u"!", u"\u00F8", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u"#", u"@", u"`"]
+			], [
+				[u"", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"\u00B0", u"+", u"BACKSPACE"],
+				[u"FIRST", u"A", u"Z", u"E", u"R", u"T", u"Y", u"U", u"I", u"O", u"P", u"\u00A3", u"{", u"}"],
+				[u"LAST", u"Q", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"M", u"%", u"\u00B5", u"ENTER"],
+				[u"SHIFT", u">", u"W", u"X", u"C", u"V", u"B", u"N", u"?", u".", u"/", u"\u00A7", u"\u00A6", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u"~", u"^", u"\\", u"\u20AC"]
+			], [
+				[u"", u"", u"\u00E2", u"\u00EA", u"\u00EE", u"\u00F4", u"\u00FB", u"\u00E4", u"\u00EB", u"\u00EF", u"\u00F6", u"\u00FC", u"", u"BACKSPACE"],
+				[u"FIRST", u"", u"\u00E0", u"\u00E8", u"\u00EC", u"\u00F2", u"\u00F9", u"\u00E1", u"\u00E9", u"\u00ED", u"\u00F3", u"\u00FA", u"", u""],
+				[u"LAST", u"", u"\u00C2", u"\u00CA", u"\u00CE", u"\u00D4", u"\u00DB", u"\u00C4", u"\u00CB", u"\u00CF", u"\u00D6", u"\u00DC", u"", u"ENTER"],
+				[u"SHIFT", u"", u"\u00C0", u"\u00C8", u"\u00CC", u"\u00D2", u"\u00D9", u"\u00C1", u"\u00C9", u"\u00CD", u"\u00D3", u"\u00DA", u"", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+			]
+		]
+		self.german = [
+			[
+				[u"", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"\u00DF", u"'", u"BACKSPACE"],
+				[u"FIRST", u"q", u"w", u"e", u"r", u"t", u"z", u"u", u"i", u"o", u"p", u"\u00FC", u"[", u"]"],
+				[u"LAST", u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"\u00F6", u"\u00E4", u"+", U"ENTER"],
+				[u"SHIFT", u"<", u"y", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"-", u"#", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u"|", u"\\", u"\u00B5"]
+			], [
+				[u"\u00B0", u"!", u"\"", u"\u00A7", u"$", u"%", u"&", u"/", u"(", u")", u"=", u"?", u"`", u"BACKSPACE"],
+				[u"FIRST", u"Q", u"W", u"E", u"R", u"T", u"Z", u"U", u"I", u"O", u"P", u"\u00DC", u"{", u"}"],
+				[u"LAST", u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"\u00D6", u"\u00C4", u"*", U"ENTER"],
+				[u"SHIFT", u">", u"Y", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"_", u"@", U"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u"\u20AC", u"\u00B2", u"\u00B3"]
+			]
+		]
+		self.russian = [
+			[
+				[u"\u0451", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"-", u"=", u"BACKSPACE"],
+				[u"FIRST", u"\u0439", u"\u0446", u"\u0443", u"\u043A", u"\u0435", u"\u043D", u"\u0433", u"\u0448", u"\u0449", u"\u0437", u"\u0445", u"\u044A", u"\u00A7"],
+				[u"LAST", u"\u0444", u"\u044B", u"\u0432", u"\u0430", u"\u043F", u"\u0440", u"\u043E", u"\u043B", u"\u0434", u"\u0436", u"\u044D", u"\\", u"ENTER"],
+				[u"SHIFT", u"\u044F", u"\u0447", u"\u0441", u"\u043C", u"\u0438", u"\u0442", u"\u044C", u"\u0431", u"\u044E", u".", u"@", u"&", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u"<"]
+			], [
+				[u"\u0401", u"!", u"\"", u"\u2116", u";", u"%", u":", u"?", u"*", u"(", u")", u"_", u"+", u"BACKSPACE"],
+				[u"FIRST", u"\u0419", u"\u0426", u"\u0423", u"\u041A", u"\u0415", u"\u041D", u"\u0413", u"\u0428", u"\u0429", u"\u0417", u"\u0425", u"\u042A", u"\u20BD"],
+				[u"LAST", u"\u0424", u"\u042B", u"\u0412", u"\u0410", u"\u041F", u"\u0420", u"\u041E", u"\u041B", u"\u0414", u"\u0416", u"\u042D", u"/", u"ENTER"],
+				[u"SHIFT", u"\u042F", u"\u0427", u"\u0421", u"\u041C", u"\u0418", u"\u0422", u"\u042C", u"\u0411", u"\u042E", u",", u"#", u"$", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u">"]
+			]
+		]
+		self.scandinavian = [
+			[
+				[u"\u00A7", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"+", u"@", u"BACKSPACE"],
+				[u"FIRST", u"q", u"w", u"e", u"r", u"t", u"y", u"u", u"i", u"o", u"p", u"\u00E5", u"[", u"]"],
+				[u"LAST", u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"\u00F6", u"\u00E4", u"'", u"ENTER"],
+				[u"SHIFT", u"<", u"z", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"-", u"\u00AB", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+			], [
+				[u"\u00BD", u"!", u"\"", u"#", u"\u00A4", u"%", u"&", u"/", u"(", u")", u"=", u"?", u"|", u"BACKSPACE"],
+				[u"FIRST", u"Q", u"W", u"E", u"R", u"T", u"Y", u"U", u"I", u"O", u"P", u"\u00C5", u"{", u"}"],
+				[u"LAST", u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"\u00D6", u"\u00C4", u"*", u"ENTER"],
+				[u"SHIFT", u">", u"Z", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"_", u"\u00BB", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+			], [
+				[u"", u"\u00E2", u"\u00EA", u"\u00EE", u"\u00F4", u"\u00FB", u"\u00E4", u"\u00EB", u"\u00EF", u"\u00F6", u"\u00FC", u"\u00E3", u"\u00F5", u"BACKSPACE"],
+				[u"FIRST", u"\u00E0", u"\u00E8", u"\u00EC", u"\u00F2", u"\u00F9", u"\u00E1", u"\u00E9", u"\u00ED", u"\u00F3", u"\u00FA", u"", u"", u""],
+				[u"LAST", u"\u00C2", u"\u00CA", u"\u00CE", u"\u00D4", u"\u00DB", u"\u00C4", u"\u00CB", u"\u00CF", u"\u00D6", u"\u00DC", u"\u00C3", u"\u00D5", u"ENTER"],
+				[u"SHIFT", u"\u00C0", u"\u00C8", u"\u00CC", u"\u00D2", u"\u00D9", u"\u00C1", u"\u00C9", u"\u00CD", u"\u00D3", u"\u00DA", u"", u"", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+			]
+		]
+		self.spanish = [
+			[
+				[u"\\", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"'", u"\u00A1", u"BACKSPACE"],
+				[u"FIRST", u"q", u"w", u"e", u"r", u"t", u"y", u"u", u"i", u"o", u"p", u"@", u"+", u"\u00E7"],
+				[u"LAST", u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"\u00F1", u"[", u"]", u"ENTER"],
+				[u"SHIFT", u"<", u"z", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"-", u"\u20AC", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u"", u"\u00E1", u"\u00E9", u"\u00ED", u"\u00F3", u"\u00FA", u"\u00FC"]
+			], [
+				[u"|", u"!", u"\"", u"\u00B7", u"$", u"%", u"&", u"/", u"(", u")", u"=", u"?", u"\u00BF", u"BACKSPACE"],
+				[u"FIRST", u"Q", u"W", u"E", u"R", u"T", u"Y", u"U", u"I", u"O", u"P", u"#", u"*", u"\u00C7"],
+				[u"LAST", u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"\u00D1", u"{", u"}", u"ENTER"],
+				[u"SHIFT", u">", u"Z", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"_", u"\u00AC", u"SHIFT"],
+				[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u"", u"\u00C1", u"\u00C9", u"\u00CD", u"\u00D3", u"\u00DA", u"\u00DC"]
+			]
+		]
+		self.locales = {
+			"ar_BH": [_("Arabic"), _("Bahrain"), self.arabic(self.english)],
+			"ar_EG": [_("Arabic"), _("Egypt"), self.arabic(self.english)],
+			"ar_JO": [_("Arabic"), _("Jordan"), self.arabic(self.english)],
+			"ar_KW": [_("Arabic"), _("Kuwait"), self.arabic(self.english)],
+			"ar_LB": [_("Arabic"), _("Lebanon"), self.arabic(self.english)],
+			"ar_OM": [_("Arabic"), _("Oman"), self.arabic(self.english)],
+			"ar_QA": [_("Arabic"), _("Qatar"), self.arabic(self.english)],
+			"ar_SA": [_("Arabic"), _("Saudi Arabia"), self.arabic(self.english)],
+			"ar_SY": [_("Arabic"), _("Syrian Arab Republic"), self.arabic(self.english)],
+			"ar_AE": [_("Arabic"), _("United Arab Emirates"), self.arabic(self.english)],
+			"ar_YE": [_("Arabic"), _("Yemen"), self.arabic(self.english)],
+			"cs_CZ": [_("Czech"), _("Czechia"), [
+				[
+					[u";", u"+", u"\u011B", u"\u0161", u"\u010D", u"\u0159", u"\u017E", u"\u00FD", u"\u00E1", u"\u00ED", u"\u00E9", u"=", u"", u"BACKSPACE"],
+					[u"FIRST", u"q", u"w", u"e", u"r", u"t", u"z", u"u", u"i", u"o", u"p", u"\u00FA", u")", u""],
+					[u"LAST", u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"\u016F", u"\u00A7", u"", u"ENTER"],
+					[u"SHIFT", u"y", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"-", u"\u0148", u"", u"SHIFT"],
+					[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+				], [
+					[u"", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"%", u"", u"BACKSPACE"],
+					[u"FIRST", u"Q", u"W", u"E", u"R", u"T", u"Z", u"U", u"I", u"O", u"P", u"/", u"(", u""],
+					[u"LAST", u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"\"", u"!", u"'", u"ENTER"],
+					[u"SHIFT", u"Y", u"X", u"C", u"V", u"B", u"N", u"M", u"?", u":", u"_", u"\u0147", u"", u"SHIFT"],
+					[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+				], [
+					[u"", u"~", u"", u"", u"", u"", u"", u"`", u"", u"", u"", u"", u"", u"BACKSPACE"],
+					[u"FIRST", u"\\", u"|", u"\u20AC", u"\u0165", u"\u0164", u"", u"", u"", u"\u00F3", u"\u00D3", u"\u00F7", u"\u00D7", u""],
+					[u"LAST", u"", u"\u0111", u"\u00D0", u"[", u"]", u"\u010F", u"\u010E", u"\u0142", u"\u0141", u"$", u"\u00DF", u"\u00A4", u"ENTER"],
+					[u"SHIFT", u"", u"#", u"&", u"@", u"{", u"}", u"", u"<", u">", u"*", u"", u"", u"SHIFT"],
+					[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+				]
+			]],
+			"nl_NL": [_("Dutch"), _("Netherlands"), self.dutch(self.english)],
+			"en_AU": [_("English"), _("Australian"), self.australian(self.english)],
+			"en_GB": [_("English"), _("United Kingdom"), self.unitedKingdom(self.english)],
+			"en_US": [_("English"), _("United States"), self.english],
+			"en_EN": [_("English"), _("Various"), self.english],
+			"et_EE": [_("Estonian"), _("Estonia"), self.estonian(self.scandinavian)],
+			"fi_FI": [_("Finnish"), _("Finland"), self.finnish(self.scandinavian)],
+			"fr_BE": [_("French"), _("Belgian"), self.belgian(self.french)],
+			"fr_FR": [_("French"), _("France"), self.french],
+			"de_DE": [_("German"), _("Germany"), self.german],
+			"el_GR": [_("Greek (Modern)"), _("Greece"), [
+				[
+					[u"`", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"-", u"=", u"BACKSPACE"],
+					[u"FIRST", u";", u"\u03C2", u"\u03B5", u"\u03C1", u"\u03C4", u"\u03C5", u"\u03B8", u"\u03B9", u"\u03BF", u"\u03C0", u"[", u"]", u"/"],
+					[u"LAST", u"\u03B1", u"\u03C3", u"\u03B4", u"\u03C6", u"\u03B3", u"\u03B7", u"\u03BE", u"\u03BA", u"\u03BB", u"", u"'", u"\\", u"ENTER"],
+					[u"SHIFT", u"<", u"\u03B6", u"\u03C7", u"\u03C8", u"\u03C9", u"\u03B2", u"\u03BD", u"\u03BC", u",", ".", u"\u03CA", u"\u03CB", u"SHIFT"],
+					[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u"\u03AC", u"\u03AD", u"\u03AE", u"\u03AF", u"\u03CC", u"\u03CD", u"\u03CE"]
+				], [
+					[u"~", u"!", u"@", u"#", u"$", u"%", u"^", u"&", u"*", u"(", u")", u"_", u"+", u"BACKSPACE"],
+					[u"FIRST", u":", u"", u"\u0395", u"\u03A1", u"\u03A4", u"\u03A5", u"\u0398", u"\u0399", u"\u039F", u"\u03A0", u"{", u"}", u"?"],
+					[u"LAST", u"\u0391", u"\u03A3", u"\u0394", u"\u03A6", u"\u0393", u"\u0397", u"\u039E", u"\u039A", u"\u039B", u"", u"\"", u"|", u"ENTER"],
+					[u"SHIFT", u">", u"\u0396", u"\u03A7", u"\u03A8", u"\u03A9", u"\u0392", u"\u039D", u"\u039C", u"<", u">", u"\u03AA", u"\u03AB", u"SHIFT"],
+					[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u"\u0386", u"\u0388", u"\u0389", u"\u038A", u"\u038C", u"\u038E", u"\u038F"]
+				], [
+					[u"", u"", u"\u00B2", u"\u00B3", u"\u00A3", u"\u00A7", u"\u00B6", u"\u20AC", u"\u00A4", u"\u00A6", u"\u00B0", u"\u00B1", u"\u00BD", u"BACKSPACE"],
+					[u"FIRST", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u""],
+					[u"LAST", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"ENTER"],
+					[u"SHIFT", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"SHIFT"],
+					[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+				]
+			]],
+			"lv_LV": [_("Latvian"), _("Latvia"), self.latvian(self.english)],
+			"nb_NO": [_("Norwegian"), _("Norway"), self.norwegian(self.scandinavian)],
+			"fa_IR": [_("Persian"), _("Iran, Islamic Republic"), self.persian(self.english)],
+			"pl_PL": [_("Polish"), _("Poland"), self.polish(self.english)],
+			"ru_RU": [_("Russian"), _("Russian Federation"), self.russian],
+			"sk_SK": [_("Slovak"), _("Slovakia"), [
+				[
+					[u"~", u"!", u"@", u"#", u"$", u"%", u"^", u"&", u"*", u"(", u")", u"\u00E1", u"\u00E4", u"BACKSPACE"],
+					[u"FIRST", u"q", u"w", u"e", u"r", u"t", u"y", u"u", u"i", u"o", u"p", u"\u010D", u"\u010F", u"\u00E9"],
+					[u"LAST", u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"\u00ED", u"\u013A", u"\u013E", u"ENTER"],
+					[u"SHIFT", u"<", u"z", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"\u0148", u"\u00F3", u"SHIFT"],
+					[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u"\u00F4", u"\u0155", u"\u0161", u"\u0165", u"\u00FA", u"\u00FD", u"\u017E"]
+				], [
+					[u"`", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"\u00C1", u"\u00C4", u"BACKSPACE"],
+					[u"FIRST", u"Q", u"W", u"E", u"R", u"T", u"Y", u"U", u"I", u"O", u"P", u"\u010C", u"\u010E", u"\u00C9"],
+					[u"LAST", u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"\u00CD", u"\u0139", u"\u013D", u"ENTER"],
+					[u"SHIFT", u">", u"Z", u"X", u"C", u"V", u"B", u"N", u"M", u"?", u":", u"\u0147", u"\u00D3", u"SHIFT"],
+					[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE", u"\u00D4", u"\u0154", u"\u0160", u"\u0164", u"\u00DA", u"\u00DD", u"\u017D"]
+				], [
+					[u"", u"", u"\u00A7", u"\u00B0", u"\u00A4", u"\u20AC", u"\u00DF", u"\u0111", u"\u0110", u"\u0142", u"\u0141", u"", u"", u"BACKSPACE"],
+					[u"FIRST", u"", u"", u"'", u"\"", u"+", u"-", u"\u00D7", u"\u00F7", u"=", u"_", u"~", u"", u""],
+					[u"LAST", u"", u"", u"/", u"\\", u";", u"[", u"]", u"{", u"}", u"|", u"", u"", u"ENTER"],
+					[u"SHIFT", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"SHIFT"],
+					[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+				]
+			]],
+			"es_ES": [_("Spanish"), _("Spain"), self.spanish],
+			"sv_SE": [_("Swedish"), _("Sweden"), self.swedish(self.scandinavian)],
+			"th_TH": [_("Thai"), _("Thailand"), [
+				[
+					[u"", u"", u"\u0E45", u"\u0E20", u"\u0E16", u"\u0E38", u"\u0E36", u"\u0E04", u"\u0E15", u"\u0E08", u"\u0E02", u"\u0E0A", u"", u"BACKSPACE"],
+					[u"FIRST", u"\u0E46", u"\u0E44", u"\u0E33", u"\u0E1E", u"\u0E30", u"\u0E31", u"\u0E35", u"\u0E23", u"\u0E19", u"\u0E22", u"\u0E1A", u"\u0E25", u""],
+					[u"LAST", u"\u0E1F", u"\u0E2B", u"\u0E01", u"\u0E14", u"\u0E40", u"\u0E49", u"\u0E48", u"\u0E32", u"\u0E2A", u"\u0E27", u"\u0E07", u"\u0E03", u"OK"],
+					[u"SHIFT", u"\u0E1C", u"\u0E1B", u"\u0E41", u"\u0E2D", u"\u0E34", u"\u0E37", u"\u0E17", u"\u0E21", u"\u0E43", u"\u0E1D", u"", u"", u"SHIFT"],
+					[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+				], [
+					[u"", u"", u"\u0E51", u"\u0E52", u"\u0E53", u"\u0E54", u"\u0E39", u"\u0E55", u"\u0E56", u"\u0E57", u"\u0E58", u"\u0E59", u"", u"BACKSPACE"],
+					[u"FIRST", u"\u0E50", u"", u"\u0E0E", u"\u0E11", u"\u0E18", u"\u0E4D", u"\u0E4A", u"\u0E13", u"\u0E2F", u"\u0E0D", u"\u0E10", u"\u0E05", u""],
+					[u"LAST", u"\u0E24", u"\u0E06", u"\u0E0F", u"\u0E42", u"\u0E0C", u"\u0E47", u"\u0E4B", u"\u0E29", u"\u0E28", u"\u0E0B", u"", u"\u0E3F", u"OK"],
+					[u"SHIFT", u"", u"", u"\u0E09", u"\u0E2E", u"\u0E3A", u"\u0E4C", u"", u"\u0E12", u"\u0E2C", u"\u0E26", u"", u"", u"SHIFT"],
+					[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+				]
+			]],
+			"uk_UA": [_("Ukrainian"), _("Ukraine"), self.ukranian(self.russian)]
+		}
+
+		self["actions"] = HelpableNumberActionMap(self, "VirtualKeyBoardActions", {
+			"cancel": (self.cancel, _("Cancel any text changes and exit")),
+			"save": (self.save, _("Save any text changes and exit")),
+			"locale": (self.localeMenu, _("Select the virtual keyboard locale from a menu")),
+			"shift": (self.shiftClicked, _("Select the virtual keyboard shifted character set")),
+			"ok": (self.processClick, _("Select the character or action under the virtual keyboard cursor")),
+			"up": (self.up, _("Move the virtual keyboard cursor up")),
+			"left": (self.left, _("Move the virtual keyboard cursor left")),
+			"right": (self.right, _("Move the virtual keyboard cursor right")),
+			"down": (self.down, _("Move the virtual keyboard cursor down")),
+			"first": (self.cursorFirst, _("Move the text buffer cursor to the first character")),
+			"prev": (self.cursorLeft, _("Move the text buffer cursor left")),
+			"next": (self.cursorRight, _("Move the text buffer cursor right")),
+			"last": (self.cursorLast, _("Move the text buffer cursor to the last character")),
+			"toggleOverwrite": (self.keyToggleOW, _("Toggle new text inserts before or overwrites existing text")),
+			"backspace": (self.backClicked, _("Delete the character to the left of text buffer cursor")),
+			"delete": (self.forwardClicked, _("Delete the character under the text buffer cursor")),
+			"1": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"2": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"3": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"4": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"5": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"6": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"7": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"8": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"9": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"0": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"gotAsciiCode": (self.keyGotAscii, _("Keyboard data entry"))
+		}, -2, description=_("Virtual KeyBoard Functions"))
+
 		self.lang = language.getLanguage()
-		self.nextLang = None
-		self.shiftMode = False
-		self.selectedKey = 0
-		self.smsChar = None
-		self.sms = NumericalTextInput(self.smsOK)
-
-		self.key_bg = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_bg.png"))
-		self.key_sel = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_sel.png"))
-		self.key_backspace = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_backspace.png"))
-		self.key_all = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_all.png"))
-		self.key_clr = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_clr.png"))
-		self.key_esc = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_esc.png"))
-		self.key_ok = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_ok.png"))
-		self.key_shift = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_shift.png"))
-		self.key_shift_sel = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_shift_sel.png"))
-		self.key_space = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_space.png"))
-		self.key_left = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_left.png"))
-		self.key_right = LoadPixmap(path=resolveFilename(SCOPE_ACTIVE_SKIN, "buttons/vkey_right.png"))
-
-		self.keyImages =  {
-				"BACKSPACE": self.key_backspace,
-				"ALL": self.key_all,
-				"EXIT": self.key_esc,
-				"OK": self.key_ok,
-				"SHIFT": self.key_shift,
-				"SPACE": self.key_space,
-				"LEFT": self.key_left,
-				"RIGHT": self.key_right
-			}
-		self.keyImagesShift = {
-				"BACKSPACE": self.key_backspace,
-				"CLEAR": self.key_clr,
-				"EXIT": self.key_esc,
-				"OK": self.key_ok,
-				"SHIFT": self.key_shift_sel,
-				"SPACE": self.key_space,
-				"LEFT": self.key_left,
-				"RIGHT": self.key_right
-			}
-
+		self["prompt"] = Label(prompt)
+		self["text"] = Input(maxSize=False, visible_width=False, type=0, currPos=len(kwargs.get("text", "").decode("utf-8", "ignore")), allMarked=False, **kwargs)  # type=TEXT(0)
+		self["list"] = VirtualKeyBoardList([])
+		self["mode"] = Label(_("INS"))
+		self["locale"] = Label(_("Locale") + ": " + self.lang)
+		self["language"] = Label(_("Language") + ": " + self.lang)
+		self["key_info"] = StaticText(_("INFO"))
 		self["key_red"] = StaticText(_("Exit"))
 		self["key_green"] = StaticText(_("Save"))
-		self["key_yellow"] = self["country"] = StaticText("")
-		self["key_blue"] = StaticText(_("Upper case"))
-		self["header"] = Label()
-		self["text"] = Input(currPos=len(kwargs.get("text", "").decode("utf-8",'ignore')), allMarked=False, **kwargs)
-		self["list"] = VirtualKeyBoardList([])
+		self["key_yellow"] = StaticText(_("Select locale"))
+		self["key_blue"] = StaticText(self.shiftMsgs[1])
+		self["key_help"] = StaticText(_("HELP"))
 
-		self["actions"] = NumberActionMap(["OkCancelActions", "WizardActions", "ColorActions", "KeyboardInputActions", "InputBoxActions", "InputAsciiActions"],
-			{
-				"gotAsciiCode": self.keyGotAscii,
-				"ok": self.okClicked,
-				"cancel": self.exit,
-				"left": self.left,
-				"right": self.right,
-				"up": self.up,
-				"down": self.down,
-				"red": self.exit,
-				"green": self.ok,
-				"yellow": self.switchLang,
-				"blue": self.shiftClicked,
-				"deleteBackward": self.backClicked,
-				"deleteForward": self.forwardClicked,
-				"back": self.exit,
-				"pageUp": self.cursorRight,
-				"pageDown": self.cursorLeft,
-				"1": self.keyNumberGlobal,
-				"2": self.keyNumberGlobal,
-				"3": self.keyNumberGlobal,
-				"4": self.keyNumberGlobal,
-				"5": self.keyNumberGlobal,
-				"6": self.keyNumberGlobal,
-				"7": self.keyNumberGlobal,
-				"8": self.keyNumberGlobal,
-				"9": self.keyNumberGlobal,
-				"0": self.keyNumberGlobal,
-			}, -2)
-		self.setLang()
+		width, self.height = skin.parameters.get("VirtualKeyBoard", (45, 45))
+		self.width = self.key_bg and self.key_bg.size().width() or width
+		self.shiftColors = skin.parameters.get("VirtualKeyBoardShiftColors", (0x00ffffff, 0x00ffffff, 0x0000ffff, 0x00ff00ff))  # Ensure there is a color for each shift level!
+		self.language = None
+		self.location = None
+		self.keyList = []
+		self.shiftLevels = 0
+		self.shiftLevel = 0
+		self.keyboardWidth = 0
+		self.keyboardHeight = 0
+		self.maxKey = 0
+		self.overwrite = False
+		self.selectedKey = 0
+		self.sms = NumericalTextInput(self.smsGotChar)
+		self.smsChar = None
+		self.setLocale()
 		self.onExecBegin.append(self.setKeyboardModeAscii)
 		self.onLayoutFinish.append(self.buildVirtualKeyBoard)
-		self.onClose.append(self.__onClose)
-	
-	def __onClose(self):
-		self.sms.timer.stop()
 
-	def switchLang(self):
-		self.lang = self.nextLang
-		self.setLang()
-		self.buildVirtualKeyBoard()
+	def arabic(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[1][0][8] = u"\u066D"
+		keyList.extend([[
+			[u"\u0630", u"\u0661", u"\u0662", u"\u0663", u"\u0664", u"\u0665", u"\u0666", u"\u0667", u"\u0668", u"\u0669", u"\u0660", u"-", u"=", u"BACKSPACE"],
+			[u"FIRST", u"\u0636", u"\u0635", u"\u062B", u"\u0642", u"\u0641", u"\u063A", u"\u0639", u"\u0647", u"\u062E", u"\u062D", u"\u062C", u"\u062F", u"\\"],
+			[u"LAST", u"\u0634", u"\u0633", u"\u064A", u"\u0628", u"\u0644", u"\u0627", u"\u062A", u"\u0646", u"\u0645", u"\u0643", u"\u0637", u"", u"ENTER"],
+			[u"SHIFT", u"\u0626", u"\u0621", u"\u0624", u"\u0631", u"\uFEFB", u"\u0649", u"\u0629", u"\u0648", u"\u0632", u"\u0638", u"", u"", u"SHIFT"],
+			[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+		], [
+			[u"\u0651", u"!", u"@", u"#", u"$", u"%", u"^", u"&", u"\u066D", u"(", u")", u"_", u"+", u"BACKSPACE"],
+			[u"FIRST", u"\u0636", u"\u0635", u"\u062B", u"\u0642", u"\u0641", u"\u063A", u"\u0639", u"\u00F7", u"\u00D7", u"\u061B", u">", u"<", u"|"],
+			[u"LAST", u"\u0634", u"\u0633", u"\u064A", u"\u0628", u"\u0644", u"\u0623", u"\u0640", u"\u060C", u"/", u":", u"\"", u"", u"ENTER"],
+			[u"SHIFT", u"\u0626", u"\u0621", u"\u0624", u"\u0631", u"\uFEF5", u"\u0622", u"\u0629", u",", u".", u"\u061F", u"", u"", u"SHIFT"],
+			[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+		]])
+		return keyList
 
-	def setLang(self):
-		if self.lang == 'de_DE':
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"q", u"w", u"e", u"r", u"t", u"z", u"u", u"i", u"o", u"p", u"ü", u"+"],
-				[u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"ö", u"ä", u"#"],
-				[u"<", u"y", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"-", u"ALL"],
-				[u"SHIFT", u"SPACE", u"@", u"ß", u"OK", u"LEFT", u"RIGHT"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u'"', u"§", u"$", u"%", u"&", u"/", u"(", u")", u"=", u"BACKSPACE"],
-				[u"Q", u"W", u"E", u"R", u"T", u"Z", u"U", u"I", u"O", u"P", u"Ü", u"*"],
-				[u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"Ö", u"Ä", u"'"],
-				[u">", u"Y", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"_", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"?", u"\\", u"OK", u"LEFT", u"RIGHT"]]
-			self.nextLang = 'es_ES'
-		elif self.lang == 'es_ES':
-			#still missing keys (u"ùÙ")
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"q", u"w", u"e", u"r", u"t", u"z", u"u", u"i", u"o", u"p", u"ú", u"+"],
-				[u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"ó", u"á", u"#"],
-				[u"<", u"y", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"-", u"ALL"],
-				[u"SHIFT", u"SPACE", u"@", u"Ł", u"ŕ", u"é", u"č", u"í", u"ě", u"ń", u"ň", u"OK"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u'"', u"§", u"$", u"%", u"&", u"/", u"(", u")", u"=", u"BACKSPACE"],
-				[u"Q", u"W", u"E", u"R", u"T", u"Z", u"U", u"I", u"O", u"P", u"Ú", u"*"],
-				[u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"Ó", u"Á", u"'"],
-				[u">", u"Y", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"_", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"?", u"\\", u"Ŕ", u"É", u"Č", u"Í", u"Ě", u"Ń", u"Ň", u"OK"]]
-			self.nextLang = 'fi_FI'
-		elif self.lang == 'fi_FI':
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"q", u"w", u"e", u"r", u"t", u"z", u"u", u"i", u"o", u"p", u"é", u"+"],
-				[u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"ö", u"ä", u"#"],
-				[u"<", u"y", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"-", u"ALL"],
-				[u"SHIFT", u"SPACE", u"@", u"ß", u"ĺ", u"OK", u"LEFT", u"RIGHT"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u'"', u"§", u"$", u"%", u"&", u"/", u"(", u")", u"=", u"BACKSPACE"],
-				[u"Q", u"W", u"E", u"R", u"T", u"Z", u"U", u"I", u"O", u"P", u"É", u"*"],
-				[u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"Ö", u"Ä", u"'"],
-				[u">", u"Y", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"_", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"?", u"\\", u"Ĺ", u"OK", u"LEFT", u"RIGHT"]]
-			self.nextLang = 'lv_LV'
-		elif self.lang == 'lv_LV':
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"q", u"w", u"e", u"r", u"t", u"y", u"u", u"i", u"o", u"p", u"-", u"š"],
-				[u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u";", u"'", u"ū"],
-				[u"<", u"z", u"x", u"c", u"v", u"b", u"n", u"m", u",", u".", u"ž", u"ALL"],
-				[u"SHIFT", u"SPACE", u"ā", u"č", u"ē", u"ģ", u"ī", u"ķ", u"ļ", u"ņ", u"LEFT", u"RIGHT"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u"@", u"$", u"*", u"(", u")", u"_", u"=", u"/", u"\\", u"BACKSPACE"],
-				[u"Q", u"W", u"E", u"R", u"T", u"Y", u"U", u"I", u"O", u"P", u"+", u"Š"],
-				[u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u":", u'"', u"Ū"],
-				[u">", u"Z", u"X", u"C", u"V", u"B", u"N", u"M", u"#", u"?", u"Ž", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"Ā", u"Č", u"Ē", u"Ģ", u"Ī", u"Ķ", u"Ļ", u"Ņ", u"LEFT", u"RIGHT"]]
-			self.nextLang = 'ru_RU'
-		elif self.lang == 'ru_RU':
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"а", u"б", u"в", u"г", u"д", u"е", u"ё", u"ж", u"з", u"и", u"й", u"+"],
-				[u"к", u"л", u"м", u"н", u"о", u"п", u"р", u"с", u"т", u"у", u"ф", u"#"],
-				[u"<", u"х", u"ц", u"ч", u"ш", u"щ", u"ъ", u"ы", u",", u".", u"-", u"ALL"],
-				[u"SHIFT", u"SPACE", u"@", u"ь", u"э", u"ю", u"я", u"OK", u"LEFT", u"RIGHT"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u'"', u"§", u"$", u"%", u"&", u"/", u"(", u")", u"=", u"BACKSPACE"],
-				[u"А", u"Б", u"В", u"Г", u"Д", u"Е", u"Ё", u"Ж", u"З", u"И", u"Й", u"*"],
-				[u"К", u"Л", u"М", u"Н", u"О", u"П", u"Р", u"С", u"Т", u"У", u"Ф", u"'"],
-				[u">", u"Х", u"Ц", u"Ч", u"Ш", u"Щ", u"Ъ", u"Ы", u";", u":", u"_", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"?", u"\\", u"Ь", u"Э", u"Ю", u"Я", u"OK", u"LEFT", u"RIGHT"]]
-			self.nextLang = 'sv_SE'
-		elif self.lang == 'sv_SE':
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"q", u"w", u"e", u"r", u"t", u"z", u"u", u"i", u"o", u"p", u"é", u"+"],
-				[u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"ö", u"ä", u"#"],
-				[u"<", u"y", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"-", u"ALL"],
-				[u"SHIFT", u"SPACE", u"@", u"ß", u"ĺ", u"OK", u"LEFT", u"RIGHT"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u'"', u"§", u"$", u"%", u"&", u"/", u"(", u")", u"=", u"BACKSPACE"],
-				[u"Q", u"W", u"E", u"R", u"T", u"Z", u"U", u"I", u"O", u"P", u"É", u"*"],
-				[u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"Ö", u"Ä", u"'"],
-				[u">", u"Y", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"_", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"?", u"\\", u"Ĺ", u"OK", u"LEFT", u"RIGHT"]]
-			self.nextLang = 'sk_SK'
-		elif self.lang =='sk_SK':
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"q", u"w", u"e", u"r", u"t", u"z", u"u", u"i", u"o", u"p", u"ú", u"+"],
-				[u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"ľ", u"@", u"#"],
-				[u"<", u"y", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"-", u"ALL"],
-				[u"SHIFT", u"SPACE", u"š", u"č", u"ž", u"ý", u"á", u"í", u"é", u"OK", u"LEFT", u"RIGHT"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u'"', u"§", u"$", u"%", u"&", u"/", u"(", u")", u"=", u"BACKSPACE"],
-				[u"Q", u"W", u"E", u"R", u"T", u"Z", u"U", u"I", u"O", u"P", u"ť", u"*"],
-				[u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"ň", u"ď", u"'"],
-				[u"Á", u"É", u"Ď", u"Í", u"Ý", u"Ó", u"Ú", u"Ž", u"Š", u"Č", u"Ť", u"Ň"],
-				[u">", u"Y", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"_", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"?", u"\\", u"ä", u"ö", u"ü", u"ô", u"ŕ", u"ĺ", u"OK"]]
-			self.nextLang = 'cs_CZ'
-		elif self.lang == 'cs_CZ':
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"q", u"w", u"e", u"r", u"t", u"z", u"u", u"i", u"o", u"p", u"ú", u"+"],
-				[u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u"ů", u"@", u"#"],
-				[u"<", u"y", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"-", u"ALL"],
-				[u"SHIFT", u"SPACE", u"ě", u"š", u"č", u"ř", u"ž", u"ý", u"á", u"í", u"é", u"OK"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u'"', u"§", u"$", u"%", u"&", u"/", u"(", u")", u"=", u"BACKSPACE"],
-				[u"Q", u"W", u"E", u"R", u"T", u"Z", u"U", u"I", u"O", u"P", u"ť", u"*"],
-				[u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"ň", u"ď", u"'"],
-				[u">", u"Y", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"_", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"?", u"\\", u"Č", u"Ř", u"Š", u"Ž", u"Ú", u"Á", u"É", u"OK"]]
-			self.nextLang = 'el_GR'
-		elif self.lang == 'el_GR':
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"=", u"ς", u"ε", u"ρ", u"τ", u"υ", u"θ", u"ι", u"ο", u"π", u"[", u"]"],
-				[u"α", u"σ", u"δ", u"φ", u"γ", u"η", u"ξ", u"κ", u"λ", u";", u"'", u"-"],
-				[u"\\", u"ζ", u"χ", u"ψ", u"ω", u"β", u"ν", u"μ", u",", ".", u"/", u"ALL"],
-				[u"SHIFT", u"SPACE", u"ά", u"έ", u"ή", u"ί", u"ό", u"ύ", u"ώ", u"ϊ", u"ϋ", u"OK"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u"@", u"#", u"$", u"%", u"^", u"&", u"*", u"(", u")", u"BACKSPACE"],
-				[u"+", u"€", u"Ε", u"Ρ", u"Τ", u"Υ", u"Θ", u"Ι", u"Ο", u"Π", u"{", u"}"],
-				[u"Α", u"Σ", u"Δ", u"Φ", u"Γ", u"Η", u"Ξ", u"Κ", u"Λ", u":", u'"', u"_"],
-				[u"|", u"Ζ", u"Χ", u"Ψ", u"Ω", u"Β", u"Ν", u"Μ", u"<", u">", u"?", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"Ά", u"Έ", u"Ή", u"Ί", u"Ό", u"Ύ", u"Ώ", u"Ϊ", u"Ϋ", u"OK"]]
-			self.nextLang = 'pl_PL'
-		elif self.lang == 'pl_PL':
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"q", u"w", u"e", u"r", u"t", u"y", u"u", u"i", u"o", u"p", u"-", u"["],
-				[u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u";", u"'", u"\\"],
-				[u"<", u"z", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"/", u"ALL"],
-				[u"SHIFT", u"SPACE", u"ą", u"ć", u"ę", u"ł", u"ń", u"ó", u"ś", u"ź", u"ż", u"OK"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u"@", u"#", u"$", u"%", u"^", u"&", u"(", u")", u"=", u"BACKSPACE"],
-				[u"Q", u"W", u"E", u"R", u"T", u"Y", u"U", u"I", u"O", u"P", u"*", u"]"],
-				[u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"?", u'"', u"|"],
-				[u">", u"Z", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"_", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"Ą", u"Ć", u"Ę", u"Ł", u"Ń", u"Ó", u"Ś", u"Ź", u"Ż", u"OK"]]
-			self.nextLang = 'th_TH'
-		elif self.lang == 'th_TH':
-			self.keys_list = [[u"EXIT", "\xe0\xb9\x85", "\xe0\xb8\xa0", "\xe0\xb8\x96", "\xe0\xb8\xb8", "\xe0\xb8\xb6", "\xe0\xb8\x84", "\xe0\xb8\x95", "\xe0\xb8\x88", "\xe0\xb8\x82", "\xe0\xb8\x8a", u"BACKSPACE"],
-				["\xe0\xb9\x86", "\xe0\xb9\x84", "\xe0\xb8\xb3", "\xe0\xb8\x9e", "\xe0\xb8\xb0", "\xe0\xb8\xb1", "\xe0\xb8\xb5", "\xe0\xb8\xa3", "\xe0\xb8\x99", "\xe0\xb8\xa2", "\xe0\xb8\x9a", "\xe0\xb8\xa5"],
-				["\xe0\xb8\x9f", "\xe0\xb8\xab", "\xe0\xb8\x81", "\xe0\xb8\x94", "\xe0\xb9\x80", "\xe0\xb9\x89", "\xe0\xb9\x88", "\xe0\xb8\xb2", "\xe0\xb8\xaa", "\xe0\xb8\xa7", "\xe0\xb8\x87", "\xe0\xb8\x83"],
-				["\xe0\xb8\x9c", "\xe0\xb8\x9b", "\xe0\xb9\x81", "\xe0\xb8\xad", "\xe0\xb8\xb4", "\xe0\xb8\xb7", "\xe0\xb8\x97", "\xe0\xb8\xa1", "\xe0\xb9\x83", "\xe0\xb8\x9d", "", u"ALL"],
-				[u"SHIFT", u"SPACE", u"OK", u"LEFT", u"RIGHT"]]
-			self.shiftkeys_list = [[u"EXIT", "\xe0\xb9\x91", "\xe0\xb9\x92", "\xe0\xb9\x93", "\xe0\xb9\x94", "\xe0\xb8\xb9", "\xe0\xb9\x95", "\xe0\xb9\x96", "\xe0\xb9\x97", "\xe0\xb9\x98", "\xe0\xb9\x99", u"BACKSPACE"],
-				["\xe0\xb9\x90", "", "\xe0\xb8\x8e", "\xe0\xb8\x91", "\xe0\xb8\x98", "\xe0\xb9\x8d", "\xe0\xb9\x8a", "\xe0\xb8\x93", "\xe0\xb8\xaf", "\xe0\xb8\x8d", "\xe0\xb8\x90", "\xe0\xb8\x85"],
-				["\xe0\xb8\xa4", "\xe0\xb8\x86", "\xe0\xb8\x8f", "\xe0\xb9\x82", "\xe0\xb8\x8c", "\xe0\xb9\x87", "\xe0\xb9\x8b", "\xe0\xb8\xa9", "\xe0\xb8\xa8", "\xe0\xb8\x8b", "", "\xe0\xb8\xbf"],
-				["", "", "\xe0\xb8\x89", "\xe0\xb8\xae", "\xe0\xb8\xba", "\xe0\xb9\x8c", "", "\xe0\xb8\x92", "\xe0\xb8\xac", "\xe0\xb8\xa6", "", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"OK", u"LEFT", u"RIGHT"]]
-			self.nextLang = 'uk_UA'
-		elif self.lang == 'uk_UA':
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"а", u"б", u"в", u"г", u"ґ", u"д", u"е", u"є", u"ж", u"з", u"и", u"+"],
-				[u"і", u"ї", u"й", u"к", u"л", u"м", u"н", u"о", u"п", u"р", u"с", u"#"],
-				[u"<", u"т", u"у", u"ф", u"х", u"ц", u"ч", u"ш", u",", u".", u"-", u"ALL"],
-				[u"SHIFT", u"SPACE", u"@", u"щ", u"ь", u"ю", u"я", u"OK", u"LEFT", u"RIGHT"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u'"', u"§", u"$", u"%", u"&", u"/", u"(", u")", u"=", u"BACKSPACE"],
-				[u"А", u"Б", u"В", u"Г", u"Ґ", u"Д", u"Е", u"Є", u"Ж", u"З", u"И", u"*"],
-				[u"І", u"Ї", u"Й", u"К", u"Л", u"М", u"Н", u"О", u"П", u"Р", u"С", u"'"],
-				[u">", u"Т", u"У", u"Ф", u"Х", u"Ц", u"Ч", u"Ш", u";", u":", u"_", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"?", u"\\", u"Щ", u"Ь", u"Ю", u"Я", u"OK", u"LEFT", u"RIGHT"]]
-			self.nextLang = 'en_EN'
-		else:
-			self.keys_list = [
-				[u"EXIT", u"1", u"2", u"3", u"4", u"5", u"6", u"7", u"8", u"9", u"0", u"BACKSPACE"],
-				[u"q", u"w", u"e", u"r", u"t", u"y", u"u", u"i", u"o", u"p", u"-", u"["],
-				[u"a", u"s", u"d", u"f", u"g", u"h", u"j", u"k", u"l", u";", u"'", u"\\"],
-				[u"<", u"z", u"x", u"c", u"v", u"b", u"n", u"m", u",", ".", u"/", u"ALL"],
-				[u"SHIFT", u"SPACE", u"OK", u"LEFT", u"RIGHT", u"*"]]
-			self.shiftkeys_list = [
-				[u"EXIT", u"!", u"@", u"#", u"$", u"%", u"^", u"&", u"(", u")", u"=", u"BACKSPACE"],
-				[u"Q", u"W", u"E", u"R", u"T", u"Y", u"U", u"I", u"O", u"P", u"+", u"]"],
-				[u"A", u"S", u"D", u"F", u"G", u"H", u"J", u"K", u"L", u"?", u'"', u"|"],
-				[u">", u"Z", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"_", u"CLEAR"],
-				[u"SHIFT", u"SPACE", u"OK", u"LEFT", u"RIGHT", u"~"]]
-			self.lang = 'en_EN'
-			self.nextLang = 'de_DE'
-		self["country"].setText(self.lang)
-		self.max_key=47+len(self.keys_list[4])
+	def australian(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[0][-1].extend([u"www.", u".com", u".net", u".org", u".edu", u".au", u".tv"])
+		keyList[1][-1].extend([u"www.", u".com", u".net", u".org", u".edu", u".au", u".tv"])
+		return keyList
+
+	def belgian(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[0][0][6] = u"\u00A7"
+		keyList[0][0][8] = u"!"
+		keyList[0][0][12] = u"-"
+		keyList[0][2][12] = u"\u00B5"
+		keyList[0][3][11] = u"="
+		keyList[0][3][12] = u""
+		keyList[1][0][0] = u"\u00B3"
+		keyList[1][0][12] = u"_"
+		keyList[1][1][11] = u"*"
+		keyList[1][2][12] = u"\u00A3"
+		keyList[1][3][11] = u"+"
+		return keyList
+
+	def dutch(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[0][0][0] = u"@"
+		keyList[0][0][11] = u"/"
+		keyList[0][0][12] = u"\u00BA"
+		keyList[0][1][11] = u"\u00A8"
+		keyList[0][1][12] = u"*"
+		keyList[0][1][13] = u"<"
+		keyList[0][2][10] = u"+"
+		keyList[0][2][11] = u"\u00B4"
+		keyList[0][2][12] = u"\\"
+		keyList[0][3] = [u"SHIFT", u"]", u"z", u"x", u"c", u"v", u"b", u"n", u"m", u",", u".", u"-", u"{", u"SHIFT"]
+		keyList[1][0] = [u"\u00A7", u"!", u"\"", u"#", u"$", u"%", u"&", u"_", u"(", u")", u"'", u"?", u"~", u"BACKSPACE"]
+		keyList[1][1][11] = u"^"
+		keyList[1][1][12] = u"|"
+		keyList[1][1][13] = u">"
+		keyList[1][2][10] = u"\u00B1"
+		keyList[1][2][11] = u"`"
+		keyList[1][2][12] = u"\u00A6"
+		keyList[1][3] = [u"SHIFT", u"[", u"Z", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"=", u"}", u"SHIFT"]
+		keyList.append([
+			[u"\u00AC", u"\u00B9", u"\u00B2", u"\u00B3", u"\u00BC", u"\u00BD", u"\u00BE", u"\u00A3", u"{", u"}", u"$", u"\\", u"", u"BACKSPACE"],
+			[u"FIRST", u"", u"", u"\u20AC", u"\u00B6", u"", u"", u"", u"", u"", u"", u"", u"", u""],
+			[u"LAST", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"ENTER"],
+			[u"SHIFT", u"\u00A6", u"\u00AB", u"\u00BB", u"\u00A2", u"", u"", u"", u"\u00B5", u"", u"\u00B7", u"", u"", u"SHIFT"],
+			[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+		])
+		return keyList
+
+	def estonian(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[0][1][11] = u"\u00FC"
+		keyList[0][1][12] = u"\u00F5"
+		keyList[0][1][13] = u"\\"
+		keyList[0][3][12] = u"\u017E"
+		keyList[0][4].extend([u"[", u"]"])
+		keyList[1][1][11] = u"\u00DC"
+		keyList[1][1][12] = u"\u00D5"
+		keyList[1][1][13] = u""
+		keyList[1][3][12] = u"\u017D"
+		keyList[1][4].extend([u"{", u"}", u"\u00A3", u"$", u"\u20AC"])
+		return keyList
+
+	def finnish(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[0][4].append(u"\\")
+		keyList[1][4].extend([u"\u00A3", u"$", u"\u20AC"])
+		return keyList
+
+	def latvian(self, base):
+		keyList = copy.deepcopy(base)
+		keyList.append([
+			[u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"BACKSPACE"],
+			[u"FIRST", u"", u"\u0113", u"\u0112", u"\u0157", u"\u0156", u"\u016B", u"\u016A", u"\u012B", u"\u012A", u"\u014D", u"\u014C", u"", u""],
+			[u"LAST", u"\u0101", u"\u0100", u"\u0161", u"\u0160", u"\u0123", u"\u0122", u"\u0137", u"\u0136", u"\u013C", u"\u013B", u"", u"", u"ENTER"],
+			[u"SHIFT", u"\u017E", u"\u017D", u"\u010D", u"\u010C", u"", u"\u0146", u"\u0145", u"", u"", u"", u"", u"", u"SHIFT"],
+			[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+		])
+		return keyList
+
+	def norwegian(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[0][0][0] = u"|"
+		keyList[0][0][12] = u"\\"
+		keyList[0][2][10] = u"\u00F8"
+		keyList[0][2][11] = u"\u00E6"
+		keyList[0][3][12] = u"\u00B5"
+		keyList[1][0][0] = u"\u00A7"
+		keyList[1][0][12] = u"@"
+		keyList[1][2][10] = u"\u00D8"
+		keyList[1][2][11] = u"\u00C6"
+		keyList[1][3][12] = u""
+		keyList[1][4].extend([u"\u00A3", u"$", u"\u20AC"])
+		return keyList
+
+	def persian(self, base):
+		keyList = copy.deepcopy(base)
+		keyList.append([
+			[u"\u00F7", u"\u06F1", u"\u06F2", u"\u06F3", u"\u06F4", u"\u06F5", u"\u06F6", u"\u06F7", u"\u06F8", u"\u06F9", u"\u06F0", u"-", u"=", u"BACKSPACE"],
+			[u"FIRST", u"\u0636", u"\u0635", u"\u062B", u"\u0642", u"\u0641", u"\u063A", u"\u0639", u"\u0647", u"\u062E", u"\u062D", u"\u062C", u"\u0686", u"\u067E"],
+			[u"LAST", u"\u0634", u"\u0633", u"\u0649", u"\u0628", u"\u0644", u"\u0622", u"\u0627", u"\u062A", u"\u0646", u"\u0645", u"\u06A9", u"\u06AF", u"ENTER"],
+			[u"SHIFT", u"\u0638", u"\u0637", u"\u0698", u"\u0632", u"\u0631", u"\u0630", u"\u062F", u"\u0626", u"\u0621", u"\u0648", u"\u060C", u"\u061F", u"SHIFT"],
+			[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
+		])
+		return keyList
+
+	def polish(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[0][3][11] = u"\u0105"
+		keyList[0][3][12] = u"\u0107"
+		keyList[0][-1].extend([u"\u0119", u"\u0141", u"\u0144", u"\u00F3", u"\u015B", u"\u017A", u"\u017C"])
+		keyList[1][2][12] = u"\u20AC"
+		keyList[1][3][11] = u"\u0104"
+		keyList[1][3][12] = u"\u0106"
+		keyList[1][-1].extend([u"\u0118", u"\u0142", u"\u0143", u"\u00D3", u"\u015A", u"\u0179", u"\u017B"])
+		return keyList
+
+	def swedish(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[0][4].extend([u"\\", u"\u00B5"])
+		keyList[1][4].extend([u"\u00A3", u"$", u"\u20AC"])
+		return keyList
+
+	def ukranian(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[0][1][12] = u"\u0457"
+		keyList[0][2][2] = u"\u0456"
+		keyList[0][2][11] = u"\u0454"
+		keyList[0][3][11] = u"\u0491"
+		keyList[0][4].append(u"@")
+		keyList[1][1][12] = u"\u0407"
+		keyList[1][2][2] = u"\u0406"
+		keyList[1][2][11] = u"\u0404"
+		keyList[1][3][11] = u"\u0490"
+		keyList[1][4].append(u"#")
+		return keyList
+
+	def unitedKingdom(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[0][1][13] = u"\u00A6"
+		keyList[0][2][12] = u"#"
+		keyList[0][3] = [u"SHIFT", u"\\", u"z", u"x", u"c", u"v", u"b", u"n", u"m", u",", u".", u"/", u"", u"SHIFT"]
+		keyList[0][-1].extend([u"\u00E1", u"\u00E9", u"\u00ED", u"\u00F3", u"\u00FA"])
+		keyList[1][0][0] = u"\u00AC"
+		keyList[1][0][2] = u"\""
+		keyList[1][0][3] = u"\u00A3"
+		keyList[1][1][13] = u"\u20AC"
+		keyList[1][2][11] = u"@"
+		keyList[1][2][12] = u"~"
+		keyList[1][3] = [u"SHIFT", u"|", u"Z", u"X", u"C", u"V", u"B", u"N", u"M", u"<", u">", u"?", u"", u"SHIFT"]
+		keyList[1][-1].extend([u"\u00C1", u"\u00C9", u"\u00CD", u"\u00D3", u"\u00DA"])
+		return keyList
+
+	def smsGotChar(self):
+		if self.smsChar and self.selectAsciiKey(self.smsChar):
+			self.processClick()
+
+	def setLocale(self):
+		self.language, self.location, self.keyList = self.locales.get(self.lang, [None, None, None])
+		if self.language is None or self.location is None or self.keyList is None:
+			self.lang = "en_EN"
+			self.language = _("English")
+			self.location = _("Various")
+			self.keyList = self.english
+		self.shiftLevel = 0
+		self["locale"].setText(_("Locale") + ": " + self.lang + "  (" + self.language + " - " + self.location + ")")
+
+	def buildVirtualKeyBoard(self):
+		self.shiftLevels = len(self.keyList)
+		if self.shiftLevel >= self.shiftLevels:
+			self.shiftLevel = 0
+		self.keyboardWidth = len(self.keyList[self.shiftLevel][0])
+		self.keyboardHeight = len(self.keyList[self.shiftLevel])
+		self.maxKey = self.keyboardWidth * (self.keyboardHeight - 1) + len(self.keyList[self.shiftLevel][-1]) - 1
+		# print "[VirtualKeyBoard] DEBUG: Width=%d, Height=%d, Keys=%d, maxKey=%d, shiftLevels=%d" % (self.keyboardWidth, self.keyboardHeight, self.maxKey + 1, self.maxKey, self.shiftLevels)
+		self.list = []
+		for keys in self.keyList[self.shiftLevel]:
+			self.list.append(self.virtualKeyBoardEntryComponent(keys))
+		self.previousSelectedKey = None
+		self.markSelectedKey()
 
 	def virtualKeyBoardEntryComponent(self, keys):
-		w, h = skin.parameters.get("VirtualKeyboard",(45, 45))
-		key_bg_width = self.key_bg and self.key_bg.size().width() or w
-		key_images = self.shiftMode and self.keyImagesShift or self.keyImages
 		res = [keys]
 		text = []
-		x = 0
+		offset = 14 - self.keyboardWidth  # 14 represents the maximum buttons per row as defined here and in the skin (14 x self.width).
+		x = self.width * offset / 2
+		if offset % 2:
+			x += self.width / 2
 		for key in keys:
-			png = key_images.get(key, None)
-			if png:
-				width = png.size().width()
-				res.append(MultiContentEntryPixmapAlphaTest(pos=(x, 0), size=(width, h), png=png))
+			image = self.keyImages[self.shiftLevel].get(key, None)
+			if image:
+				width = image.size().width()
+				res.append(MultiContentEntryPixmapAlphaBlend(pos=(x, 0), size=(width, self.height), png=image))
 			else:
-				width = key_bg_width
-				res.append(MultiContentEntryPixmapAlphaTest(pos=(x, 0), size=(width, h), png=self.key_bg))
-				text.append(MultiContentEntryText(pos=(x, 0), size=(width, h), font=0, text=key.encode("utf-8"), flags=RT_HALIGN_CENTER | RT_VALIGN_CENTER))
+				width = self.width
+				res.append(MultiContentEntryPixmapAlphaBlend(pos=(x, 0), size=(width, self.height), png=self.keyBackgrounds.get(key, self.key_bg)))
+				if len(key) > 1:  # NOTE: UTF8 / Unicode glyphs only count as one character here.
+					text.append(MultiContentEntryText(pos=(x, 0), size=(width, self.height), font=1, flags=RT_HALIGN_CENTER | RT_VALIGN_CENTER, text=_(key.encode("utf-8")), color=self.shiftColors[self.shiftLevel]))
+				else:
+					text.append(MultiContentEntryText(pos=(x, 0), size=(width, self.height), font=0, flags=RT_HALIGN_CENTER | RT_VALIGN_CENTER, text=key.encode("utf-8"), color=self.shiftColors[self.shiftLevel]))
+
 			x += width
 		return res + text
 
-	def buildVirtualKeyBoard(self):
-		self.previousSelectedKey = None
-		self.list = []
-		for keys in self.shiftMode and self.shiftkeys_list or self.keys_list:
-			self.list.append(self.virtualKeyBoardEntryComponent(keys))
-		self.markSelectedKey()
-
 	def markSelectedKey(self):
-		w, h = skin.parameters.get("VirtualKeyboard",(45, 45))
 		if self.previousSelectedKey is not None:
-			self.list[self.previousSelectedKey /12] = self.list[self.previousSelectedKey /12][:-1]
-		width = self.key_sel.size().width()
-		x = self.list[self.selectedKey/12][self.selectedKey % 12 + 1][1]
-		self.list[self.selectedKey / 12].append(MultiContentEntryPixmapAlphaTest(pos=(x, 0), size=(width, h), png=self.key_sel))
+			self.list[self.previousSelectedKey / self.keyboardWidth] = self.list[self.previousSelectedKey / self.keyboardWidth][:-1]
+		if self.selectedKey > self.maxKey:
+			self.selectedKey = self.maxKey
+		x = self.list[self.selectedKey / self.keyboardWidth][self.selectedKey % self.keyboardWidth + 1][1]
+		self.list[self.selectedKey / self.keyboardWidth].append(MultiContentEntryPixmapAlphaBlend(pos=(x, 0), size=(self.key_sel.size().width(), self.height), png=self.key_sel))
 		self.previousSelectedKey = self.selectedKey
 		self["list"].setList(self.list)
+
+	def processClick(self):
+		self.smsChar = None
+		text = self.keyList[self.shiftLevel][self.selectedKey / self.keyboardWidth][self.selectedKey % self.keyboardWidth].encode("UTF-8")
+		if text == u"":
+			pass
+		elif text == u"ALL":
+			self["text"].markAll()
+		elif text == u"BACK":
+			self["text"].deleteBackward()
+		elif text == u"BACKSPACE":
+			self["text"].deleteBackward()
+		elif text == u"BLANK":
+			pass
+		elif text == u"CLR":
+			self["text"].deleteAllChars()
+			self["text"].update()
+		elif text == u"ENTER":
+			self.save()
+		elif text == u"ESC":
+			self.cancel()
+		elif text == u"EXIT":
+			self.cancel()
+		elif text == u"FIRST":
+			self["text"].home()
+		elif text == u"LOC":
+			self.localeMenu()
+		elif text == u"LAST":
+			self["text"].end()
+		elif text == u"LEFT":
+			self["text"].left()
+		elif text == u"OK":
+			self.save()
+		elif text == u"RIGHT":
+			self["text"].right()
+		elif text == u"SAVE":
+			self.save()
+		elif text == u"SHIFT":
+			self.shiftClicked()
+		elif text == u"Shift":
+			self.shiftClicked()
+		elif text == u"SPACE":
+			self["text"].char(" ".encode("UTF-8"))
+		else:
+			self["text"].char(text.encode("UTF-8"))
+
+	def cancel(self):
+		self.close(None)
+
+	def save(self):
+		self.close(self["text"].getText())
+
+	def localeMenu(self):
+		languages = []
+		for locale, data in self.locales.iteritems():
+			languages.append((data[0] + "  -  " + data[1] + "  (" + locale + ")", locale))
+		languages = sorted(languages)
+		index = 0
+		default = 0
+		for item in languages:
+			if item[1] == self.lang:
+				default = index
+				break
+			index += 1
+		self.session.openWithCallback(self.localeMenuCallback, ChoiceBox, _("Available locales are:"), list=languages, selection=default, keys=[])
+
+	def localeMenuCallback(self, choice):
+		if choice:
+			self.lang = choice[1]
+			self.setLocale()
+			self.buildVirtualKeyBoard()
+
+	def shiftClicked(self):
+		self.smsChar = None
+		self.shiftLevel = (self.shiftLevel + 1) % self.shiftLevels
+		nextLevel = (self.shiftLevel + 1) % self.shiftLevels
+		self["key_blue"].setText(self.shiftMsgs[nextLevel])
+		self.buildVirtualKeyBoard()
+
+	def keyToggleOW(self):
+		self["text"].toggleOverwrite()
+		self.overwrite = not self.overwrite
+		if self.overwrite:
+			self["mode"].setText(_("OVR"))
+		else:
+			self["mode"].setText(_("INS"))
 
 	def backClicked(self):
 		self["text"].deleteBackward()
@@ -350,117 +829,70 @@ class VirtualKeyBoard(Screen):
 	def forwardClicked(self):
 		self["text"].deleteForward()
 
-	def shiftClicked(self):
-		self.smsChar = None
-		self.shiftMode = not self.shiftMode
-		self.buildVirtualKeyBoard()
-		self["key_blue"].setText(self.shiftMode and _("Lower case") or _("Upper case"))
-
-	def okClicked(self):
-		self.smsChar = None
-		text = (self.shiftMode and self.shiftkeys_list or self.keys_list)[self.selectedKey / 12][self.selectedKey % 12].encode("UTF-8")
-
-		if text == "EXIT":
-			self.close(None)
-
-		elif text == "BACKSPACE":
-			self["text"].deleteBackward()
-
-		elif text == "ALL":
-			self["text"].markAll()
-
-		elif text == "CLEAR":
-			self["text"].deleteAllChars()
-			self["text"].update()
-
-		elif text == "SHIFT":
-			self.shiftClicked()
-
-		elif text == "SPACE":
-			self["text"].char(" ".encode("UTF-8"))
-
-		elif text == "OK":
-			self.close(self["text"].getText())
-
-		elif text == "LEFT":
-			self["text"].left()
-
-		elif text == "RIGHT":
-			self["text"].right()
-
-		else:
-			self["text"].char(text)
-
-	def ok(self):
-		self.close(self["text"].getText())
-
-	def exit(self):
-		self.close(None)
-
-	def cursorRight(self):
-		self["text"].right()
+	def cursorFirst(self):
+		self["text"].home()
 
 	def cursorLeft(self):
 		self["text"].left()
 
+	def cursorRight(self):
+		self["text"].right()
+
+	def cursorLast(self):
+		self["text"].end()
+
+	def up(self):
+		self.smsChar = None
+		self.selectedKey -= self.keyboardWidth
+		if self.selectedKey < 0:
+			self.selectedKey = self.maxKey / self.keyboardWidth * self.keyboardWidth + self.selectedKey % self.keyboardWidth
+			if self.selectedKey > self.maxKey:
+				self.selectedKey -= self.keyboardWidth
+		self.markSelectedKey()
+
 	def left(self):
 		self.smsChar = None
-		self.selectedKey = self.selectedKey / 12 * 12 + (self.selectedKey + 11) % 12
-		if self.selectedKey > self.max_key:
-			self.selectedKey = self.max_key
+		self.selectedKey = self.selectedKey / self.keyboardWidth * self.keyboardWidth + (self.selectedKey + self.keyboardWidth - 1) % self.keyboardWidth
+		if self.selectedKey > self.maxKey:
+			self.selectedKey = self.maxKey
 		self.markSelectedKey()
 
 	def right(self):
 		self.smsChar = None
-		self.selectedKey = self.selectedKey / 12 * 12 + (self.selectedKey + 1) % 12
-		if self.selectedKey > self.max_key:
-			self.selectedKey = self.selectedKey / 12 * 12
-		self.markSelectedKey()
-
-	def up(self):
-		self.smsChar = None
-		self.selectedKey -= 12
-		if self.selectedKey < 0:
-			self.selectedKey = self.max_key / 12 * 12 + self.selectedKey % 12
-			if self.selectedKey > self.max_key:
-				self.selectedKey -= 12
+		self.selectedKey = self.selectedKey / self.keyboardWidth * self.keyboardWidth + (self.selectedKey + 1) % self.keyboardWidth
+		if self.selectedKey > self.maxKey:
+			self.selectedKey = self.selectedKey / self.keyboardWidth * self.keyboardWidth
 		self.markSelectedKey()
 
 	def down(self):
 		self.smsChar = None
-		self.selectedKey += 12
-		if self.selectedKey > self.max_key:
-			self.selectedKey %= 12
+		self.selectedKey += self.keyboardWidth
+		if self.selectedKey > self.maxKey:
+			self.selectedKey %= self.keyboardWidth
 		self.markSelectedKey()
 
 	def keyNumberGlobal(self, number):
 		self.smsChar = self.sms.getKey(number)
 		self.selectAsciiKey(self.smsChar)
 
-	def smsOK(self):
-		if self.smsChar and self.selectAsciiKey(self.smsChar):
-			print "[VirtualKeyboard] pressing ok now"
-			self.okClicked()
-
 	def keyGotAscii(self):
 		self.smsChar = None
-		if self.selectAsciiKey(str(unichr(getPrevAsciiCode()).encode('utf-8'))):
-			self.okClicked()
+		if self.selectAsciiKey(str(unichr(getPrevAsciiCode()).encode("utf-8"))):
+			self.processClick()
 
 	def selectAsciiKey(self, char):
-		if char == " ":
-			char = "SPACE"
-		for keyslist in (self.shiftkeys_list, self.keys_list):
+		if char == u" ":
+			char = u"SPACE"
+		self.shiftLevel = -1
+		for keyList in (self.keyList):
+			self.shiftLevel = (self.shiftLevel + 1) % self.shiftLevels
+			self.buildVirtualKeyBoard()
 			selkey = 0
-			for keys in keyslist:
+			for keys in keyList:
 				for key in keys:
 					if key == char:
 						self.selectedKey = selkey
-						if self.shiftMode != (keyslist is self.shiftkeys_list):
-							self.shiftMode = not self.shiftMode
-							self.buildVirtualKeyBoard()
-						else:
-							self.markSelectedKey()
+						self.markSelectedKey()
 						return True
 					selkey += 1
 		return False


### PR DESCRIPTION
[VirtualKeyBoard.py] Refactor code

This is a complete rewrite of the VirtualKeyBoard code. Changes, in no particular order, are:
- Widen the keyboard grid to 14 characters to allow for a more realistic imaging of real keyboards
- The width is now defined by a single variable, all VirtualKeyBoard calculations are now based on this one value
- If the keymap describes a keyboard layout less than 14 characters the keyboard will be centred in the reserved screen area
- There can now be a large number of shift levels coded though only 4 levels are provided by default
- All text based graphical buttons have been redone as translatable text overlay buttons
- All text buttons on each shift level can now be assigned different foreground colours
- The VirtualKeyBoard now has its own distinct ActionMap called "VirtualKeyBoardActions"
- Help descriptions have been added to all ActionMap entries
- Short text entries can be assigned to any button, they will be shown at a reduced front size so as to fit up to about 4 characters
- All text based buttons are now put through the language translation system
- All keyboard buttons are now defined in unicode so that a UTF-8 aware editor is no longer required
- Any button or function can be assigned to a colour button (Defaults: RED->Exit, GREEN->Save, YELLOW->Locale, BLUE-Shift)
- Any button or function can be assigned to a graphical button (matching images need to be created and added to the code)
- Users may now navigate around the VirtualKeyBoard grid AND the text buffer
- Insert and overwrite modes are now available
- The current insert/overwrite mode status is now shown to the user
- Keyboard layouts can now be separate / independent or based on another keyboard layout
- The VirtualKeyBoard supports the standard screen colour buttons and/or the colour buttons displayed on the VirtualKeyBoard
- The initial locale will be matched to the current operating locale, if a match is not found then en_EN (English - Various) is selected
- Pressing YELLOW will now pop up a menu of available locales rather than randomly moving through the locale list
- All locales now have a description of the language and the country
- The VirtualKeyBoard now accepts input via navigation around the grid, by direct SMS character selection and via an attached keyboard
- Some new languages have been added
- The new code uses the automatic skin button code proposed in /doc/BUTTONGUIDE
- The source code documentation has been duplicated and added to /doc/VIRTUALKEYBOARD
- The new code is PEP8 compliant
- There may be more but I think this list is long enough ;)

Add documentation for the new VirtualKeyBoard

- This documentation matches the comments / documentation encoded in the new VirtualKeyBoard.

[keymap.xml] Add mapping for new VirtualKeyBoard

- This key map includes definitions for the remote control and for an attached physical keyboard.
