### PR TITLE
[NumericalTextInput.py] Enforce character restrictions

### DIFF
--- a/lib/python/Tools/NumericalTextInput.py
+++ b/lib/python/Tools/NumericalTextInput.py
@@ -230,7 +230,11 @@ class NumericalTextInput:
 					if locale[num][index] is not None:
 						self.mapping[num] = locale[num][index]
 			self.mapping = tuple(self.mapping)
-		self.useableChars = None
+		# The key mapping lists naturally restricts character input to
+		# the listed characters, this restriction is not enforced for
+		# external keyboard input!
+		self.useableChars = "".join(self.mapping)  # This limits data entry to only characters in the mapping lists.
+		# print "[NumericalTextInput] DEBUG: Mode='%s', Index=%d, Character set: '%s'" % (mode, index, "".join(sorted(self.useableChars)))
 		self.lastKey = -1
 		self.pos = -1
 


### PR DESCRIPTION
The key mapping options naturally restrict character input to the listed characters in the mapping lists, this restriction is not enforced for external keyboard input!  This code restoration ensures that only characters that are permitted can be accepted.

The issue could best be seen if HEX input is required.  Using the SMS data entry mode only the characters 0-9, A-F and a-f (as appropriate) can be entered.  Without this code change an external keyboard could enter any character on the keyboard.  With this code change only the permitted 0-9, A-F and a-f (as appropriate) will be accepted.

This code was accidentally omitted from the initial commit.
