### PR TITLE
[TimerEntry.py] Fix LEFT/RIGHT invoking VirtualKeyBoard

### DIFF
--- a/lib/python/Screens/TimerEntry.py
+++ b/lib/python/Screens/TimerEntry.py
@@ -275,8 +275,6 @@ class TimerEntry(Screen, ConfigListScreen):
 		cur = self["config"].getCurrent()
 		if cur in (self.channelEntry, self.tagsSet):
 			self.keySelect()
-		elif cur in (self.entryName, self.entryDescription):
-			self.renameEntry()
 		else:
 			ConfigListScreen.keyLeft(self)
 			self.newConfig()
@@ -285,8 +283,6 @@ class TimerEntry(Screen, ConfigListScreen):
 		cur = self["config"].getCurrent()
 		if cur in (self.channelEntry, self.tagsSet):
 			self.keySelect()
-		elif cur in (self.entryName, self.entryDescription):
-			self.renameEntry()
 		else:
 			ConfigListScreen.keyRight(self)
 			self.newConfig()


### PR DESCRIPTION
This correction stops the LEFT or RIGHT arrow buttons from invoking the VirtualKeyBoard in the "Name" or "Description" fields rather than navigating the current text buffer.  The VirtualKeyBoard is still available via the TEXT button as usual.
