### PR TITLE
[config.py] Fix extra_args management

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -29,13 +29,12 @@ from time import localtime, strftime
 #
 class ConfigElement(object):
 	def __init__(self):
-		self.extra_args = {}
 		self.saved_value = None
 		self.save_forced = False
 		self.last_value = None
 		self.save_disabled = False
 		self.__notifiers = None
-		self.__notifiers_final = None
+		self.__notifiersFinal = None
 		self.enabled = True
 		self.callNotifiersOnSaveAndCancel = False  # this flag only affects notifiers set with "immediate_feedback = False". If set to false the notifier will never run on save/exit by default.
 
@@ -50,14 +49,15 @@ class ConfigElement(object):
 	notifiers = property(getNotifiers, setNotifiers)
 
 	def getNotifiersFinal(self):
-		if self.__notifiers_final is None:
-			self.__notifiers_final = []
-		return self.__notifiers_final
+		if self.__notifiersFinal is None:
+			self.__notifiersFinal = []
+		return self.__notifiersFinal
 
 	def setNotifiersFinal(self, val):
-		self.__notifiers_final = val
+		self.__notifiersFinal = val
 
-	notifiers_final = property(getNotifiersFinal, setNotifiersFinal)
+	notifiersFinal = property(getNotifiersFinal, setNotifiersFinal)
+	notifiers_final = property(getNotifiersFinal, setNotifiersFinal)  # Deprecated legacy interface!
 
 	# you need to override this to do input validation
 	def setValue(self, value):
@@ -90,13 +90,13 @@ class ConfigElement(object):
 			self.saved_value = None
 		else:
 			self.saved_value = self.tostring(self.value)
-#		if self.callNotifiersOnSaveAndCancel:
-		self.changedFinal()  # call none immediate_feedback notifiers, immediate_feedback Notifiers are called as they are chanaged, so do not need to be called here.
+		if self.callNotifiersOnSaveAndCancel:
+			self.changedFinal()  # call none immediate_feedback notifiers, immediate_feedback Notifiers are called as they are chanaged, so do not need to be called here.
 
 	def cancel(self):
 		self.load()
-#		if self.callNotifiersOnSaveAndCancel:
-		self.changedFinal()  # call none immediate_feedback notifiers, immediate_feedback Notifiers are called as they are chanaged, so do not need to be called here.
+		if self.callNotifiersOnSaveAndCancel:
+			self.changedFinal()  # call none immediate_feedback notifiers, immediate_feedback Notifiers are called as they are chanaged, so do not need to be called here.
 
 	def isChanged(self):
 		# NOTE - self.saved_value should already be stringified!
@@ -108,66 +108,80 @@ class ConfigElement(object):
 	def changed(self):
 		if self.__notifiers:
 			for x in self.notifiers:
-				try:
-					if self.extra_args[x]:
-						x(self, self.extra_args[x])
-					else:
-						x(self)
-				except BaseException:
+				if isinstance(x, tuple):
+					notifier, args = x
+					notifier(self, args)
+				else:
 					x(self)
 
 	def changedFinal(self):
-		if self.__notifiers_final:
-			for x in self.notifiers_final:
-				try:
-					if self.extra_args[x]:
-						x(self, self.extra_args[x])
-					else:
-						x(self)
-				except BaseException:
+		if self.__notifiersFinal:
+			for x in self.notifiersFinal:
+				if isinstance(x, tuple):
+					notifier, args = x
+					notifier(self, args)
+				else:
 					x(self)
 
 	def addNotifier(self, notifier, initial_call=True, immediate_feedback=True, extra_args=None):
-		if not extra_args:
-			extra_args = []
-		assert callable(notifier), "notifiers must be callable"
-		try:
-			self.extra_args[notifier] = extra_args
-		except BaseException:
-			pass
-		if immediate_feedback:
-			self.notifiers.append(notifier)
+		assert callable(notifier), "[Config] Error: All notifiers must be callable!"
+		if extra_args is not None:
+			print "[Config] Warning: 'addNotifier()' with extra_args is fatally flawed!  Use 'addNotifierWithArgs()' and 'removeNotifierWithArgs()' instead."
+			self.addNotifierWithArgs(notifier, extra_args, initial_call=initial_call, immediate_feedback=immediate_feedback)
 		else:
-			self.notifiers_final.append(notifier)
-		# CHECKME:
-		# do we want to call the notifier
-		#  - at all when adding it? (yes, though optional)
-		#  - when the default is active? (yes)
-		#  - when no value *yet* has been set,
-		#    because no config has ever been read (currently yes)
-		#    (though that's not so easy to detect.
-		#     the entry could just be new.)
-		if initial_call:
-			if extra_args:
-				notifier(self, extra_args)
+			if immediate_feedback:
+				self.notifiers.append(notifier)
 			else:
+				self.notifiersFinal.append(notifier)
+			# CHECKLIST:
+			# Do we want to call the notifier
+			# - at all when adding it? (Yes, though optional)
+			# - when the default is active? (Yes)
+			# - when no value *yet* has been set,
+			#   because no config has ever been read (currently Yes)
+			# (That's not so easy to detect. The entry could just be new.)
+			if initial_call:
 				notifier(self)
 
 	def removeNotifier(self, notifier):
-		notifier in self.notifiers and self.notifiers.remove(notifier)
-		notifier in self.notifiers_final and self.notifiers_final.remove(notifier)
-		try:
-			del self.__notifiers[str(notifier)]
-		except BaseException:
-			pass
-		try:
-			del self.__notifiers_final[str(notifier)]
-		except BaseException:
-			pass
+		if notifier in self.notifiers:
+			self.notifiers.remove(notifier)
+		else:
+			for x in self.notifiers:
+				if isinstance(x, tuple):
+					notify, args = x
+					if notify is notifier:
+						self.notifiers.remove(x)
+						break
+		if notifier in self.notifiersFinal:
+			self.notifiersFinal.remove(notifier)
+		else:
+			for x in self.notifiersFinal:
+				if isinstance(x, tuple):
+					notify, args = x
+					if notify is notifier:
+						self.notifiersFinal.remove(x)
+						break
+
+	def addNotifierWithArgs(self, notifier, args, initial_call=True, immediate_feedback=True):
+		assert callable(notifier), "[Config] Error: All notifiers must be callable!"
+		if immediate_feedback:
+			self.notifiers.append((notifier, args))
+		else:
+			self.notifiersFinal.append((notifier, args))
+		if initial_call:
+			notifier(self, args)
+
+	def removeNotifierWithArgs(self, notifier, args):
+		notify = (notifier, args)
+		if notify in self.notifiers:
+			self.notifiers.remove(notify)
+		if notify in self.notifiersFinal:
+			self.notifiersFinal.remove(notify)
 
 	def clearNotifiers(self):
-		self.__notifiers = {}
-		self.__notifiers_final = {}
+		self.__notifiers = None
+		self.__notifiersFinal = None
 
 	def disableSave(self):
 		self.save_disabled = True


### PR DESCRIPTION
There is a critical fatal flaw in the ConfigElement notifier code with particular reference to the handling of the "extra_args" parameter. The current code tries to use a hash of the notifier method as the key to a dictionary. This is illegal! The errors have been hidden by try / except blocks rather than trying to understand or fix the underlying problem.  The effect of the problem was that attempts to access the extra_args would fail with "TypeError: unhashable type: 'xyz'" and the version of the callback without the "extra_args" would be used instead.  (This causes the "extra_args" information to be lost.)

To address this issue two new methods have been created "addNotifierWithArgs()" and "removeNotifierWithArgs()" that will correctly associate the args with the notifier to which they apply.  For code compatibility any calls to "addNotifier()" with an "extra_args" parameter will be passed to "addNotifierWithArgs()" for correct processing.  A warning of this redirection will be logged so that coders can update their code to use the working mechanisms.  The protective try / except protection has been removed as the underlying issue has been resolved.

While correcting the "extra_args" I have also taken the opportunity to harmonise the internal storage names of the notifiers.  "notifiers_final" is now called "notifiersFinal" to better match the variable naming conventions used elsewhere in this code.  I deprecated the old name as it did not follow the style for all the other notifier names. Consistency and predictability makes it easier to remember variable names and spot mistakes.

Thanks to IanB for assisting address this issue.
