### PR TITLE
[config.py] Fix extra_args management (2)

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -125,7 +125,7 @@ class ConfigElement(object):
 		assert callable(notifier), "[Config] Error: All notifiers must be callable!"
 		if not extra_args:
 			extra_args = []
-		self.extra_args[id(notifier)] = extra_args
+		self.extra_args[id(notifier)] = extra_args  # NOTE: Only one extra_args can be stored per notifier instance.
 		if immediate_feedback:
 			self.notifiers.append(notifier)
 		else:

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -34,28 +34,30 @@ class ConfigElement(object):
 		self.save_forced = False
 		self.last_value = None
 		self.save_disabled = False
-		self.__notifiers = None
-		self.__notifiers_final = None
+		self.__notifiers = []
+		self.__notifiers_final = []
 		self.enabled = True
 		self.callNotifiersOnSaveAndCancel = False  # this flag only affects notifiers set with "immediate_feedback = False". If set to false the notifier will never run on save/exit by default.
 
 	def getNotifiers(self):
-		if self.__notifiers is None:
-			self.__notifiers = []
 		return self.__notifiers
 
 	def setNotifiers(self, val):
-		self.__notifiers = val
+		if isinstance(val, list):
+			self.__notifiers = val
+		else:
+			self.__notifiers = list(val)
 
 	notifiers = property(getNotifiers, setNotifiers)
 
 	def getNotifiersFinal(self):
-		if self.__notifiers_final is None:
-			self.__notifiers_final = []
 		return self.__notifiers_final
 
 	def setNotifiersFinal(self, val):
-		self.__notifiers_final = val
+		if isinstance(val, list):
+			self.__notifiers_final = val
+		else:
+			self.__notifiers_final = list(val)
 
 	notifiers_final = property(getNotifiersFinal, setNotifiersFinal)
 
@@ -152,8 +154,8 @@ class ConfigElement(object):
 			del self.extra_args[id(notifier)]
 
 	def clearNotifiers(self):
-		self.__notifiers = None
-		self.__notifiers_final = None
+		self.__notifiers = []
+		self.__notifiers_final = []
 		self.extra_args = {}
 
 	def disableSave(self):

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -108,45 +108,35 @@ class ConfigElement(object):
 	def changed(self):
 		if self.__notifiers:
 			for x in self.notifiers:
-				try:
-					if self.extra_args[x]:
-						x(self, self.extra_args[x])
-					else:
-						x(self)
-				except BaseException:
+				if self.extra_args[id(x)]:
+					x(self, self.extra_args[id(x)])
+				else:
 					x(self)
 
 	def changedFinal(self):
 		if self.__notifiers_final:
 			for x in self.notifiers_final:
-				try:
-					if self.extra_args[x]:
-						x(self, self.extra_args[x])
-					else:
-						x(self)
-				except BaseException:
+				if self.extra_args[id(x)]:
+					x(self, self.extra_args[id(x)])
+				else:
 					x(self)
 
 	def addNotifier(self, notifier, initial_call=True, immediate_feedback=True, extra_args=None):
+		assert callable(notifier), "[Config] Error: All notifiers must be callable!"
 		if not extra_args:
 			extra_args = []
-		assert callable(notifier), "notifiers must be callable"
-		try:
-			self.extra_args[notifier] = extra_args
-		except BaseException:
-			pass
+		self.extra_args[id(notifier)] = extra_args
 		if immediate_feedback:
 			self.notifiers.append(notifier)
 		else:
 			self.notifiers_final.append(notifier)
-		# CHECKME:
-		# do we want to call the notifier
-		#  - at all when adding it? (yes, though optional)
-		#  - when the default is active? (yes)
-		#  - when no value *yet* has been set,
-		#    because no config has ever been read (currently yes)
-		#    (though that's not so easy to detect.
-		#     the entry could just be new.)
+		# CHECKLIST:
+		# Do we want to call the notifier
+		# - at all when adding it? (Yes, though optional)
+		# - when the default is active? (Yes)
+		# - when no value *yet* has been set,
+		#   because no config has ever been read (currently Yes)
+		# (That's not so easy to detect. The entry could just be new.)
 		if initial_call:
 			if extra_args:
 				notifier(self, extra_args)
@@ -154,20 +144,17 @@ class ConfigElement(object):
 				notifier(self)
 
 	def removeNotifier(self, notifier):
-		notifier in self.notifiers and self.notifiers.remove(notifier)
-		notifier in self.notifiers_final and self.notifiers_final.remove(notifier)
-		try:
-			del self.__notifiers[str(notifier)]
-		except BaseException:
-			pass
-		try:
-			del self.__notifiers_final[str(notifier)]
-		except BaseException:
-			pass
+		if notifier in self.notifiers:
+			self.notifiers.remove(notifier)
+		if notifier in self.notifiers_final:
+			self.notifiers_final.remove(notifier)
+		if self.extra_args[id(notifier)]:
+			del self.extra_args[id(notifier)]
 
 	def clearNotifiers(self):
-		self.__notifiers = {}
-		self.__notifiers_final = {}
+		self.__notifiers = None
+		self.__notifiers_final = None
+		self.extra_args = {}
 
 	def disableSave(self):
 		self.save_disabled = True

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -43,10 +43,7 @@ class ConfigElement(object):
 		return self.__notifiers
 
 	def setNotifiers(self, val):
-		if isinstance(val, list):
-			self.__notifiers = val
-		else:
-			self.__notifiers = list(val)
+		self.__notifiers = val or []
 
 	notifiers = property(getNotifiers, setNotifiers)
 
@@ -54,10 +51,7 @@ class ConfigElement(object):
 		return self.__notifiers_final
 
 	def setNotifiersFinal(self, val):
-		if isinstance(val, list):
-			self.__notifiers_final = val
-		else:
-			self.__notifiers_final = list(val)
+		self.__notifiers_final = val or []
 
 	notifiers_final = property(getNotifiersFinal, setNotifiersFinal)
 


### PR DESCRIPTION
There is a critical flaw in the ConfigElement notifier code with particular reference to the handling of the "extra_args" parameter. The current code tries to use a hash of the notifier method as the key to a dictionary. This is illegal! The errors have been hidden by try / except blocks rather than trying to understand or fix the underlying problem. The effect of the problem was that attempts to access the extra_args would fail with "TypeError: unhashable type: 'xyz'" and the version of the callback without the "extra_args" would be used instead. (This causes the "extra_args" information to be lost.)

Rather than using the notifier itself as the key use it's id() instead.  The protective try / except protection has been removed as the underlying issue has been resolved.

Thanks to IanB and Prl for assisting address this issue.
