### PR TITLE
[config.py] Prepare for "extra_args" removal

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -119,9 +119,14 @@ class ConfigElement(object):
 
 	def addNotifier(self, notifier, initial_call=True, immediate_feedback=True, extra_args=None):
 		assert callable(notifier), "[Config] Error: All notifiers must be callable!"
-		if not extra_args:
+		if extra_args:
+			print "[Config] =========================================================================="
+			print "[Config] WARNING: The "extra_args" argument is deprecated and will be removed soon!"
+			print "[Config]          Please switch to using a boundFunction() on the notifier instead."
+			print "[Config] =========================================================================="
+		else:
 			extra_args = []
-		self.extra_args[id(notifier)] = extra_args  # NOTE: Only one extra_args can be stored per notifier instance.
+		self.extra_args[id(notifier)] = extra_args
 		if immediate_feedback:
 			self.notifiers.append(notifier)
 		else:

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -121,7 +121,7 @@ class ConfigElement(object):
 		assert callable(notifier), "[Config] Error: All notifiers must be callable!"
 		if extra_args:
 			print "[Config] =========================================================================="
-			print "[Config] WARNING: The "extra_args" argument is deprecated and will be removed soon!"
+			print "[Config] WARNING: The 'extra_args' argument is deprecated and will be removed soon!"
 			print "[Config]          Please switch to using a boundFunction() on the notifier instead."
 			print "[Config] =========================================================================="
 		else:


### PR DESCRIPTION
This change keeps the new "extra_args" functionality but adds a log message warning about its intended removal.
