### PR TITLE
[GitCommitInfo.py] Protect "AboutScrollLabel" from non string content

### DIFF
--- a/lib/python/Screens/GitCommitInfo.py
+++ b/lib/python/Screens/GitCommitInfo.py
@@ -212,7 +212,7 @@ class CommitInfo(Screen):
 
 	def readGithubCommitLogs(self):
 		self.updateScreenTitle(gitcommitinfo.getScreenTitle())
-		self["AboutScrollLabel"].setText(gitcommitinfo.readGithubCommitLogs())
+		self["AboutScrollLabel"].setText(str(gitcommitinfo.readGithubCommitLogs()))
 
 	def updateCommitLogs(self):
 		if gitcommitinfo.cachedProjects.has_key(gitcommitinfo.getScreenTitle()):

--- a/lib/python/Screens/GitCommitInfo.py
+++ b/lib/python/Screens/GitCommitInfo.py
@@ -212,7 +212,7 @@ class CommitInfo(Screen):
 
 	def readGithubCommitLogs(self):
 		self.updateScreenTitle(gitcommitinfo.getScreenTitle())
-		self["AboutScrollLabel"].setText(str(gitcommitinfo.readGithubCommitLogs()))
+		self["AboutScrollLabel"].setText(gitcommitinfo.readGithubCommitLogs().encode())
 
 	def updateCommitLogs(self):
 		if gitcommitinfo.cachedProjects.has_key(gitcommitinfo.getScreenTitle()):


### PR DESCRIPTION
Casting the "gitcommitinfo.readGithubCommitLogs()" as string protects the "setText()" method from crashing on any questionable data in the text returned.
