### PR TITLE
[GitCommitInfo.py] Add missing "utf8" parameter to encode()

### DIFF
--- a/lib/python/Screens/GitCommitInfo.py
+++ b/lib/python/Screens/GitCommitInfo.py
@@ -212,7 +212,7 @@ class CommitInfo(Screen):
 
 	def readGithubCommitLogs(self):
 		self.updateScreenTitle(gitcommitinfo.getScreenTitle())
-		self["AboutScrollLabel"].setText(gitcommitinfo.readGithubCommitLogs().encode())
+		self["AboutScrollLabel"].setText(gitcommitinfo.readGithubCommitLogs().encode("utf8"))
 
 	def updateCommitLogs(self):
 		if gitcommitinfo.cachedProjects.has_key(gitcommitinfo.getScreenTitle()):

--- a/lib/python/Screens/GitCommitInfo.py
+++ b/lib/python/Screens/GitCommitInfo.py
@@ -212,7 +212,7 @@ class CommitInfo(Screen):
 
 	def readGithubCommitLogs(self):
 		self.updateScreenTitle(gitcommitinfo.getScreenTitle())
-		self["AboutScrollLabel"].setText(gitcommitinfo.readGithubCommitLogs().encode("utf8"))
+		self["AboutScrollLabel"].setText(gitcommitinfo.readGithubCommitLogs().encode("utf8", errors="ignore"))
 
 	def updateCommitLogs(self):
 		if gitcommitinfo.cachedProjects.has_key(gitcommitinfo.getScreenTitle()):


### PR DESCRIPTION
This corrects a missing parameter issue on the recent commit.

Thanks Prl for pointing out the problem.
