### PR TITLE
[VirtualKeyBoard.py] Remove unnecessary okClicked method

### DIFF
--- a/lib/python/Screens/VirtualKeyBoard.py
+++ b/lib/python/Screens/VirtualKeyBoard.py
@@ -669,9 +669,6 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 		self.previousSelectedKey = self.selectedKey
 		self["list"].setList(self.list)
 
-	def okClicked(self):  # Deprecated legacy interface to new processSelect used by YouTubeVirtualKeyBoard
-		self.processSelect()
-
 	def processSelect(self):
 		self.smsChar = None
 		text = self.keyList[self.shiftLevel][self.selectedKey / self.keyboardWidth][self.selectedKey % self.keyboardWidth].encode("UTF-8")


### PR DESCRIPTION
The deprecated legacy okClicked() method interface to new processSelect() method as used by YouTubeVirtualKeyBoard is no longer required.
