### PR TITLE
[enigma2.sh.in] Add option for skin backdrops

### DIFF
--- a/tools/enigma2.sh.in
+++ b/tools/enigma2.sh.in
@@ -25,7 +25,7 @@ if [ -e /proc/stb/info/boxtype ]; then
 fi
 
 if [ -x @bindir@/showiframe ]; then
-	skin=`sed -En 's;config\.skin\.primary_skin=(.+)/skin\.xml;\1;p' @sysconfdir@/enigma2/settings`
+	skin=`sed -En 's|config\.skin\.primary_skin=(.+)/skin\.xml|\1|p' @sysconfdir@/enigma2/settings`
 	if [ -z $skin ]; then
 		skin=`strings -n 10 @prefix@/lib/enigma2/python/skin.pyo | egrep -o -m 1 ".+/skin.xml" | sed 's|/skin.xml.*||'`
 	fi

--- a/tools/enigma2.sh.in
+++ b/tools/enigma2.sh.in
@@ -25,7 +25,13 @@ if [ -e /proc/stb/info/boxtype ]; then
 fi
 
 if [ -x @bindir@/showiframe ]; then
-	if [ -f @sysconfdir@/enigma2/backdrop.mvi ]; then
+	skin=`sed -En 's;config\.skin\.primary_skin=(.+)/skin\.xml;\1;p' @sysconfdir@/enigma2/settings`
+	if [ -z $skin ]; then
+		skin=`strings -n 10 @prefix@/lib/enigma2/python/skin.pyo | egrep -o -m 1 ".+/skin.xml" | sed 's|/skin.xml.*||'`
+	fi
+	if [ -n $skin -a -f @datarootdir@/enigma2/$skin/backdrop.mvi ]; then
+		@bindir@/showiframe @datarootdir@/enigma2/$skin/backdrop.mvi
+	elif [ -f @sysconfdir@/enigma2/backdrop.mvi ]; then
 		@bindir@/showiframe @sysconfdir@/enigma2/backdrop.mvi
 	elif [ -f @datadir@/backdrop.mvi ]; then
 		@bindir@/showiframe @datadir@/backdrop.mvi


### PR DESCRIPTION
This change adds the option for skins to include a backdrop.mvi image at the top level of the skin that will be used when that skin is selected.

The code first checks to see if a skin is defined in the "settings" file and uses it if found.  If no skin is identified then the "skin.pyo" file is searched to see if a built-in skin has been defined.  If found then that will be used.  If no skin associated backdrop is identified then the code will progress to the original search in "/etc/enigma2/" and finally use the image in "/usr/share/".
