### PR TITLE
[keymap.xml] Add EPG button to VirtualKeyBoard

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -85,6 +85,7 @@
 		<key id="KEY_PLAYPAUSE" mapto="delete" flags="mr" />
 		<key id="KEY_PLAY" mapto="delete" flags="mr" />
 		<key id="KEY_INFO" mapto="toggleOverwrite" flags="m" />
+		<key id="KEY_EPG" mapto="toggleOverwrite" flags="m" />
 		<key id="KEY_0" mapto="0" flags="m" />
 		<key id="KEY_1" mapto="1" flags="m" />
 		<key id="KEY_2" mapto="2" flags="m" />


### PR DESCRIPTION
This change adds the EPG button as a duplicate for the INFO button.  This has been done to allow remote controls that do not have an INFO button to still have access to the Insert/Overwrite mode.
