### PR TITLE
Test update to make display800 skin compatible with new SkinSelector

### DIFF
--- a/data/display800/Default_with_Picon_Fullscreen/skin_display.xml
+++ b/data/display800/Default_with_Picon_Fullscreen/skin_display.xml
@@ -62,5 +62,5 @@
 		<panel name="LCDFullPicon" />
 	</screen>
 
-	<include filename="/usr/share/enigma2/display/skin_display_templates.xml"/>
+	<include filename="/usr/share/enigma2/display/skin_default/skin_display_templates.xml"/>
 </skin>

--- a/data/display800/Makefile.am
+++ b/data/display800/Makefile.am
@@ -1,7 +1,4 @@
 SUBDIRS = Default_with_Picon_Fullscreen
 
 installdir = $(pkgdatadir)/display/skin_default
-dist_install_DATA = *.png *.ttf
-
-datainstalldir = $(pkgdatadir)/display
-dist_datainstall_DATA = *.xml piconprev.png prev.png
+dist_install_DATA = *.xml *.png *.ttf piconprev.png prev.png

--- a/data/display800/skin_display.xml
+++ b/data/display800/skin_display.xml
@@ -78,5 +78,5 @@
 		<panel name="LCDRecordIcon" />
 	</screen>
 
-	<include filename="/usr/share/enigma2/display/skin_display_templates.xml"/>
+	<include filename="skin_display_templates.xml"/>
 </skin>

--- a/data/display800/skin_display_picon.xml
+++ b/data/display800/skin_display_picon.xml
@@ -81,5 +81,5 @@
 		<panel name="LCDRecordIcon" />
 	</screen>
 
-	<include filename="/usr/share/enigma2/display/skin_display_templates.xml"/>
+	<include filename="skin_display_templates.xml"/>
 </skin>


### PR DESCRIPTION
- [Makefile.am] Move skin XML to new location

    This change moves the skin display components for this display skin to its new location as part of the "skin.py" and "SkinSelector.py" refactors.

- [skin_display.xml] Use skin relative path for includes

- [skin_display_picon.xml] Use skin relative path for includes

- [skin_display.xml] Update location of template file

  This change updates the new location of this skin's display template.

  An alternate, an possibly better, update would be to add a copy of the template file into this skin.  This would mean that this skin is totally self complete.
