### PR TITLE
Test update to make 7segment skin compatible with new SkinSelector

### DIFF
--- a/data/7segment/Makefile.am
+++ b/data/7segment/Makefile.am
@@ -1,2 +1,2 @@
-installdir = $(pkgdatadir)/display
+installdir = $(pkgdatadir)/display/skin_default
 dist_install_DATA = *.xml


### PR DESCRIPTION
- [Makefile.am] Move skin XML to new location

  This change moves the skin display components for this display skin to its new location as part of the "skin.py" and "SkinSelector.py" refactors.
