### PR TITLE
Test update to make display128 skin compatible with new SkinSelector

### DIFF
--- a/data/display128/Makefile.am
+++ b/data/display128/Makefile.am
@@ -1,2 +1,2 @@
-installdir = $(pkgdatadir)/display
+installdir = $(pkgdatadir)/display/skin_default
 dist_install_DATA = *.xml


### PR DESCRIPTION
- [Makefile.am] Move skin XML to new location

  This change moves the skin display components for this display skin to its new location as part of the "skin.py" and "SkinSelector.py" refactors.
