### PR TITLE
Test update to make vfd128 skin compatible with new SkinSelector

### DIFF
--- a/data/vfd128/Makefile.am
+++ b/data/vfd128/Makefile.am
@@ -1,5 +1,2 @@
 installdir = $(pkgdatadir)/display/skin_default
-dist_install_DATA = update.png txt.png tuner-d.png tuner-d-act.png tuner-c.png tuner-c-act.png tuner-b.png tuner-b-act.png tuner-a.png tuner-a-act.png stop.png slow.png rec.png play.png pause.png hd.png forward.png format.png dolby.png crypt.png backward.png 
-
-datainstalldir = $(pkgdatadir)/display
-dist_datainstall_DATA = *.xml prev.png piconprev.png
+dist_install_DATA = *.xml prev.png piconprev.png update.png txt.png tuner-d.png tuner-d-act.png tuner-c.png tuner-c-act.png tuner-b.png tuner-b-act.png tuner-a.png tuner-a-act.png stop.png slow.png rec.png play.png pause.png hd.png forward.png format.png dolby.png crypt.png backward.png 


### PR DESCRIPTION
- [Makefile.am] Move skin files to new location

  This change moves the skin display components for this display skin to its new location as part of the "skin.py" and "SkinSelector.py" refactors.
