### PR TITLE
[skin.py] Apply more fixes and improvements

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -272,8 +272,10 @@ def parseColor(s):
 	return gRGB(int(s[1:], 0x10))
 
 def parseParameter(s):
-	"""This function is responsible for parsing parameters in the skin, it can parse integers, floats, hex colors, hex integers and named colors."""
-	if s[0] == "#":
+	"""This function is responsible for parsing parameters in the skin, it can parse integers, floats, hex colors, hex integers, named colors and strings."""
+	if s[0] == "*":
+		return s[1:]
+	elif s[0] == "#":
 		return int(s[1:], 16)
 	elif s[:2] == "0x":
 		return int(s, 16)

--- a/skin.py
+++ b/skin.py
@@ -126,7 +126,7 @@ addSkin(SUBTITLE_SKIN, scope=SCOPE_CURRENT_SKIN)
 
 # Add the front panel / display / lcd skin.
 result = []
-for skin, name in [(config.skin.display_skin.value, "current"), (DEFAULT_SKIN, "default")]:
+for skin, name in [(config.skin.display_skin.value, "current"), (DEFAULT_DISPLAY_SKIN, "default")]:
 	if skin in result:  # Don't try to add a skin that has already failed.
 		continue
 	config.skin.display_skin.value = skin
@@ -333,10 +333,10 @@ def collectAttributes(skinAttributes, node, context, skinPath=None, ignore=(), f
 
 def morphRcImagePath(value):
 	if rc_model.rcIsDefault() is False:
-		# if value == "/usr/share/enigma2/skin_default/rc.png" or value == "/usr/share/enigma2/skin_default/rcold.png":  # OpenPLi version.
+		# if value in ("/usr/share/enigma2/skin_default/rc.png", "/usr/share/enigma2/skin_default/rcold.png"):  # OpenPLi version.
 		# 	value = rc_model.getRcImg()
-		if ("rc.png" or "oldrc.png") in value:
-			value = rc_model.getRcLocation() + "rc.png"
+		if ("rc.png" or "oldrc.png") in value:  # OpenViX version.
+			value = "%src.png" % rc_model.getRcLocation()
 	return value
 
 def loadPixmap(path, desktop):
@@ -874,9 +874,10 @@ def loadSkin(filename, scope=SCOPE_SKIN):
 								elem.clear()
 								continue
 							if name in domScreens:
-								# Clear old versions, save memory.
-								domScreens[name][0].clear()
-							domScreens[name] = (elem, path)
+								print "[Skin] Warning: Screen '%s' already defined!  Using first definition." % name
+								elem.clear()
+							else:
+								domScreens[name] = (elem, path)
 						else:
 							# Without a name, it's useless!
 							elem.clear()


### PR DESCRIPTION
 - [skin.py] Add ability to store strings in parameters

- [skin.py] Various improvements and cleanups
  - Use appropriate scopes for addskin() calls.
  - Rename findUserRelated() method to findUserRelatedSkin().
  - Use a loop to load the display and GUI skins to reduce the code complexity while maintaining a fallback sequence.
  - Delete global working variables.
  - Add skin loading enhancements from addSkin() method to loadSkin() method.
  - Camel case some more variables.
  - Remove old code comment blocks.
  - Remove unnecessary global definitions.
  - Improve screen processing logs.

- [skin.py] More corrections and enhancements
  - Use correct default for the display skin.
  - Optimise the morphRcImagePath() method.
  - Improve loadSkin() method to add logging for duplicated screens.  (Only the first screen definition is used.)
