### PR TITLE
[SkinSelector.py] Harden code against potential crash

### DIFF
--- a/lib/python/Screens/SkinSelector.py
+++ b/lib/python/Screens/SkinSelector.py
@@ -143,7 +143,10 @@ class SkinSelector(Screen, HelpableScreen):
 					if skinFile == "skin.xml":
 						with open(skinPath) as chan:
 							resolution = chan.read(65536)
-						resolution = re.search("\<resolution.*?\syres\s*=\s*\"(\d+)\"", resolution).group(1)
+						try:
+							resolution = re.search("\<resolution.*?\syres\s*=\s*\"(\d+)\"", resolution).group(1)
+						except Exception:
+							resolution = ""
 						resolution = resolutions.get(resolution, None)
 						msg = "an unknown" if resolution is None else "a %s" % resolution
 						print "[SkinSelector] Skin '%s' is %s resolution skin." % (skinPath, msg)


### PR DESCRIPTION
This change places the regular expression that looks for the skin resolution into a try/except structure.  Some skins do not contain the resolution information, or even an "output" block.  This used to cause the code to crash.  Now if there is a problem finding the resolution a blank string is returned instead.
