### PR TITLE
[Directories.py] Add two new scopes

### DIFF
--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import errno
+import inspect
 import os
 
 from enigma import eEnv, getDesktop
@@ -21,6 +23,8 @@ SCOPE_PLUGINS = 9
 SCOPE_MEDIA = 10
 SCOPE_PLAYLIST = 11
 SCOPE_CURRENT_SKIN = 12
+SCOPE_CURRENT_PLUGIN_FULL = 13
+SCOPE_CURRENT_PLUGIN_RELATIVE = 14
 
 SCOPE_METADIR = 16
 SCOPE_CURRENT_PLUGIN = 17
@@ -60,7 +64,9 @@ defaultPaths = {
 	SCOPE_AUTORECORD: ("/media/hdd/movie/", PATH_DONTCREATE),
 	SCOPE_DEFAULTDIR: (eEnv.resolve("${datadir}/enigma2/defaults/"), PATH_CREATE),
 	SCOPE_DEFAULTPARTITION: ("/dev/mtdblock6", PATH_DONTCREATE),
-	SCOPE_DEFAULTPARTITIONMOUNTDIR: (eEnv.resolve("${datadir}/enigma2/dealer"), PATH_CREATE)
+	SCOPE_DEFAULTPARTITIONMOUNTDIR: (eEnv.resolve("${datadir}/enigma2/dealer"), PATH_CREATE),
+	SCOPE_CURRENT_PLUGIN_FULL: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_DONTCREATE),
+	SCOPE_CURRENT_PLUGIN_RELATIVE: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_DONTCREATE)
 }
 
 def resolveFilename(scope, base="", path_prefix=None):
@@ -83,8 +89,8 @@ def resolveFilename(scope, base="", path_prefix=None):
 	if flag == PATH_CREATE and not pathExists(path):
 		try:
 			os.makedirs(path)
-		except OSError, e:
-			print "[Directories] Error %d: Couldn't create directory '%s' (%s)" % (e.errno, path, os.strerror(e.errno))
+		except (IOError, OSError) as err:
+			print "[Directories] Error %d: Couldn't create directory '%s' (%s)" % (err.errno, path, err.strerror)
 			return None
 	# Remove any suffix data and restore it at the end.
 	suffix = None
@@ -102,6 +108,15 @@ def resolveFilename(scope, base="", path_prefix=None):
 			from Components.config import config
 			skin = os.path.dirname(config.skin.primary_skin.value)
 			path = os.path.join(path, skin)
+		elif scope in (SCOPE_CURRENT_PLUGIN_FULL, SCOPE_CURRENT_PLUGIN_RELATIVE):
+			callingCode = os.path.normpath(inspect.stack()[1][1])
+			plugins = os.path.normpath(defaultPaths[SCOPE_PLUGINS][0])
+			path = None
+			if comparePath(plugins, callingCode):
+				pluginCode = callingCode[len(plugins) + 1:].split(os.sep)
+				if len(pluginCode) > 2:
+					relative = "%s%s%s" % (pluginCode[0], os.sep, pluginCode[1])
+					path = os.path.join(plugins, relative)
 	elif scope in (SCOPE_CURRENT_SKIN, SCOPE_ACTIVE_SKIN):
 		# This import must be here as this module finds the config file as part of the config initialisation.
 		from Components.config import config
@@ -169,6 +184,15 @@ def resolveFilename(scope, base="", path_prefix=None):
 		file = os.path.join(defaultPaths[SCOPE_PLUGINS][0], base)
 		if pathExists(file):
 			path = file
+	elif scope in (SCOPE_CURRENT_PLUGIN_FULL, SCOPE_CURRENT_PLUGIN_RELATIVE):
+		callingCode = os.path.normpath(inspect.stack()[1][1])
+		plugins = os.path.normpath(defaultPaths[SCOPE_PLUGINS][0])
+		path = None
+		if comparePath(plugins, callingCode):
+			pluginCode = callingCode[len(plugins) + 1:].split(os.sep)
+			if len(pluginCode) > 2:
+				relative = os.path.join("%s%s%s" % (pluginCode[0], os.sep, pluginCode[1]), base)
+				path = os.path.join(plugins, relative)
 	else:
 		path, flags = defaultPaths.get(scope)
 		path = os.path.join(path, base)
@@ -176,10 +200,24 @@ def resolveFilename(scope, base="", path_prefix=None):
 	# If the path is a directory then ensure that it ends with a "/".
 	if os.path.isdir(path) and not path.endswith("/"):
 		path += "/"
+	if scope == SCOPE_CURRENT_PLUGIN_RELATIVE:
+		path = path[len(plugins) + 1:]
 	# If a suffix was supplier restore it.
 	if suffix is not None:
 		path = "%s:%s" % (path, suffix)
 	return path
+
+def comparePath(leftPath, rightPath):
+	if leftPath.endswith(os.sep):
+		leftPath = leftPath[:-1]
+	if rightPath.endswith(os.sep):
+		rightPath = rightPath[:-1]
+	left = leftPath.split(os.sep)
+	right = rightPath.split(os.sep)
+	for segment in range(len(left)):
+		if left[segment] != right[segment]:
+			return False
+	return True
 
 def bestRecordingLocation(candidates):
 	path = ""
@@ -194,8 +232,8 @@ def bestRecordingLocation(candidates):
 				if size > biggest:
 					biggest = size
 					path = candidate[1]
-		except Exception, e:
-			print "[Directories] Error %d: Couldn't get free space for '%s' (%s)" % (e.errno, candidate[1], os.strerror(e.errno))
+		except (IOError, OSError) as err:
+			print "[Directories] Error %d: Couldn't get free space for '%s' (%s)" % (err.errno, candidate[1], err.strerror)
 	return path
 
 def defaultRecordingLocation(candidate=None):
@@ -326,8 +364,8 @@ def copyfile(src, dst):
 			if not buf:
 				break
 			f2.write(buf)
-	except OSError, e:
-		print "[Directories] Error %d: Copying file '%s' to '%s'! (%s)" % (e.errno, src, dst, os.strerror(e.errno))
+	except (IOError, OSError) as err:
+		print "[Directories] Error %d: Copying file '%s' to '%s'! (%s)" % (err.errno, src, dst, err.strerror)
 		status = -1
 	if f1 is not None:
 		f1.close()
@@ -337,14 +375,14 @@ def copyfile(src, dst):
 		st = os.stat(src)
 		try:
 			os.chmod(dst, S_IMODE(st.st_mode))
-		except OSError, e:
-			print "[Directories] Error %d: Setting modes from '%s' to '%s'! (%s)" % (e.errno, src, dst, os.strerror(e.errno))
+		except (IOError, OSError) as err:
+			print "[Directories] Error %d: Setting modes from '%s' to '%s'! (%s)" % (err.errno, src, dst, err.strerror)
 		try:
 			os.utime(dst, (st.st_atime, st.st_mtime))
-		except OSError, e:
-			print "[Directories] Error %d: Setting times from '%s' to '%s'! (%s)" % (e.errno, src, dst, os.strerror(e.errno))
-	except OSError, e:
-		print "[Directories] Error %d: Obtaining stats from '%s' to '%s'! (%s)" % (e.errno, src, dst, os.strerror(e.errno))
+		except (IOError, OSError) as err:
+			print "[Directories] Error %d: Setting times from '%s' to '%s'! (%s)" % (err.errno, src, dst, err.strerror)
+	except (IOError, OSError) as err:
+		print "[Directories] Error %d: Obtaining stats from '%s' to '%s'! (%s)" % (err.errno, src, dst, err.strerror)
 	return status
 
 def copytree(src, dst, symlinks=False):
@@ -366,20 +404,20 @@ def copytree(src, dst, symlinks=False):
 				copytree(srcname, dstname, symlinks)
 			else:
 				copyfile(srcname, dstname)
-		except OSError, e:
-			print "[Directories] Error %d: Copying tree '%s' to '%s'! (%s)" % (e.errno, srcname, dstname, os.strerror(e.errno))
+		except (IOError, OSError) as err:
+			print "[Directories] Error %d: Copying tree '%s' to '%s'! (%s)" % (err.errno, srcname, dstname, err.strerror)
 	try:
 		st = os.stat(src)
 		try:
 			os.chmod(dst, S_IMODE(st.st_mode))
-		except OSError, e:
-			print "[Directories] Error %d: Setting modes from '%s' to '%s'! (%s)" % (e.errno, src, dst, os.strerror(e.errno))
+		except (IOError, OSError) as err:
+			print "[Directories] Error %d: Setting modes from '%s' to '%s'! (%s)" % (err.errno, src, dst, err.strerror)
 		try:
 			os.utime(dst, (st.st_atime, st.st_mtime))
-		except OSError, e:
-			print "[Directories] Error %d: Setting times from '%s' to '%s'! (%s)" % (e.errno, src, dst, os.strerror(e.errno))
-	except OSError, e:
-		print "[Directories] Error %d: Obtaining stats from '%s' to '%s'! (%s)" % (e.errno, src, dst, os.strerror(e.errno))
+		except (IOError, OSError) as err:
+			print "[Directories] Error %d: Setting times from '%s' to '%s'! (%s)" % (err.errno, src, dst, err.strerror)
+	except (IOError, OSError) as err:
+		print "[Directories] Error %d: Obtaining stats from '%s' to '%s'! (%s)" % (err.errno, src, dst, err.strerror)
 
 # Renames files or if source and destination are on different devices moves them in background
 # input list of (source, destination)
@@ -391,23 +429,23 @@ def moveFiles(fileList):
 		for item in fileList:
 			os.rename(item[0], item[1])
 			movedList.append(item)
-	except OSError, e:
-		if e.errno == 18:  # errno.EXDEV - Invalid cross-device link
+	except (IOError, OSError) as err:
+		if err.errno == errno.EXDEV:  # Invalid cross-device link
 			print "[Directories] Warning: Cannot rename across devices, trying slower move."
 			from Tools.CopyFiles import moveFiles as extMoveFiles  # OpenViX, OpenATV, Beyonwiz
 			# from Screens.CopyFiles import moveFiles as extMoveFiles  # OpenPLi
 			extMoveFiles(fileList, item[0])
 			print "[Directories] Moving files in background."
 		else:
-			print "[Directories] Error %d: Moving file '%s' to '%s'! (%s)" % (e.errno, item[0], item[1], os.strerror(e.errno))
+			print "[Directories] Error %d: Moving file '%s' to '%s'! (%s)" % (err.errno, item[0], item[1], err.strerror)
 			errorFlag = True
 	if errorFlag:
 		print "[Directories] Reversing renamed files due to error."
 		for item in movedList:
 			try:
 				os.rename(item[1], item[0])
-			except OSError, e:
-				print "[Directories] Error %d: Renaming '%s' to '%s'! (%s)" % (e.errno, item[1], item[0], os.strerror(e.errno))
+			except (IOError, OSError) as err:
+				print "[Directories] Error %d: Renaming '%s' to '%s'! (%s)" % (err.errno, item[1], item[0], err.strerror)
 				print "[Directories] Failed to undo move:", item
 
 def getSize(path, pattern=".*"):


### PR DESCRIPTION
- Add two new scopes to add more options for developers to abstract their code.

  SCOPE_CURRENT_PLUGIN_FULL returns the absolute path of the current plugin if called from within a plugin.  If this scope is called from code other than a plugin it returns None.

  SCOPE_CURRENT_PLUGIN_RELATIVE returns the relative path of the current plugin if called from within a plugin.  The path fragment returned is relative to SCOPE_PLUGINS.  Again, if this scope is called from code other than a plugin it returns None.

  Using os.path.join(resolveFilename(SCOPE_PLUGINS), resolveFilename(SCOPE_CURRENT_PLUGIN_RELATIVE)) the result should be the same as resolveFilename(SCOPE_CURRENT_PLUGIN_FULL).

  These scopes can also be used with base data to create paths within the current plugin.

  At the moment SCOPE_CURRENT_PLUGIN returns the same path as SCOPE_PLUGINS.  In an ideal world the new SCOPE_CURRENT_PLUGIN_FULL should replace the existing SCOPE_CURRENT_PLUGIN!

- Adjust exceptions to be more Python 3 compatible.
