### PR TITLE
[skin.py] Fix a few hard coded skin attributes

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -454,7 +454,8 @@ class AttributeParser:
 			print "[Skin] Error: Invalid alphatest '%s'!  Must be one of 'on', 'off' or 'blend'." % value
 
 	def scale(self, value):
-		self.guiObject.setScale(1)
+		value = 1 if value.lower() in ("1", "enabled", "on", "scale", "true", "yes") else 0
+		self.guiObject.setScale(value)
 
 	def orientation(self, value):  # used by eSlider
 		try:
@@ -572,7 +573,8 @@ class AttributeParser:
 			print "[Skin] Error: Invalid scrollbarMode '%s'!  Must be one of 'showOnDemand', 'showAlways', 'showNever' or 'showLeft'." % value
 
 	def enableWrapAround(self, value):
-		self.guiObject.setWrapAround(True)
+		value = True if value.lower() in ("1", "enabled", "enablewraparound", "on", "true", "yes") else False
+		self.guiObject.setWrapAround(value)
 
 	def itemHeight(self, value):
 		self.guiObject.setItemHeight(int(value))
@@ -593,7 +595,8 @@ class AttributeParser:
 		self.guiObject.setShadowOffset(parsePosition(value, self.scaleTuple))
 
 	def noWrap(self, value):
-		self.guiObject.setNoWrap(1)
+		value = 1 if value.lower() in ("1", "enabled", "nowrap", "on", "true", "yes") else 0
+		self.guiObject.setNoWrap(value)
 
 def applySingleAttribute(guiObject, desktop, attrib, value, scale=((1, 1), (1, 1))):
 	# Is anyone still using applySingleAttribute?


### PR DESCRIPTION
Change the "scale", "enableWrapAround" and "noWrap" skin tag attributes so that skin provided values are no longer ignored and replaced with hardcoded default values.  Some validation is done of the attribute values.  The old values "0" and "1" are still valid.  Skinners can now also use case insensitive "Yes", "Enabled", "On", "True", "Yes" and the attribute name as alternate values to indicate that the attribute is being asserted.  Any other values will be considered that the attribute is being negated.
