### PR TITLE
[SkinSelector.py] Improve display if restart is aborted

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -122,6 +122,7 @@ for skin, name in [(config.skin.primary_skin.value, "current"), (DEFAULT_SKIN, "
 		continue
 	config.skin.primary_skin.value = skin
 	if addSkin(config.skin.primary_skin.value, scope=SCOPE_CURRENT_SKIN):
+		currentPrimarySkin = config.skin.primary_skin.value
 		break
 	print "[Skin] Error: Adding %s GUI skin '%s' has failed!" % (name, config.skin.primary_skin.value)
 	result.append(skin)
@@ -133,6 +134,7 @@ for skin, name in [(config.skin.display_skin.value, "current"), (DEFAULT_DISPLAY
 		continue
 	config.skin.display_skin.value = skin
 	if addSkin(config.skin.display_skin.value, scope=SCOPE_CURRENT_LCDSKIN):
+		currentDisplaySkin = config.skin.display_skin.value
 		break
 	print "[Skin] Error: Adding %s display skin '%s' has failed!" % (name, config.skin.display_skin.value)
 	result.append(skin)


### PR DESCRIPTION
- Add new variables "currentPrimarySkin" and "currentDisplaySkin" to "skin.py" to allow "SkinSelector.py" to know both the configured Primary and Display skins as well as the current Primary and Display skins.

- Add a new status message to the skin list display to indicate if the newly selected skin is not yet active due to a pending GUI restart.

- Improve the layout and readability of the "rescueData" list.  Each line now corresponds to a line in the embedded skin.

- Improve the documentation comment regarding the hack skin.
