### PR TITLE
[SkinSelector.py] Rework embedded skin and restart logic

### DIFF
--- a/lib/python/Screens/SkinSelector.py
+++ b/lib/python/Screens/SkinSelector.py
@@ -19,48 +19,7 @@ from Tools.Directories import resolveFilename, SCOPE_CURRENT_SKIN, SCOPE_LCDSKIN
 
 
 class SkinSelector(Screen, HelpableScreen):
-	def __init__(self, session, menu_path="", screenTitle=_("GUI Skin")):
-		self.hackSkin()  # This is a hack to ensure the skin's SkinConverter screen works with the new code.
-		Screen.__init__(self, session)
-		HelpableScreen.__init__(self)
-		if config.usage.show_menupath.value == 'large':
-			menu_path += screenTitle
-			title = menu_path
-			self["menu_path_compressed"] = StaticText("")
-		elif config.usage.show_menupath.value == 'small':
-			title = screenTitle
-			self["menu_path_compressed"] = StaticText(menu_path + " >" if not menu_path.endswith(" / ") else menu_path[:-3] + " >" or "")
-		else:
-			title = screenTitle
-			self["menu_path_compressed"] = StaticText("")
-		Screen.setTitle(self, title)
-		self.skinName = ["SkinSelector"]
-		self.rootDir = resolveFilename(SCOPE_SKIN)
-		self.config = config.skin.primary_skin
-		self.current = currentPrimarySkin
-		self.xmlList = ["skin.xml"]
-		self.onChangedEntry = []
-		self["skins"] = List(enableWrapAround=True)
-		self["preview"] = Pixmap()
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
-		self["description"] = StaticText(_("Please wait... Loading list..."))
-		self["actions"] = HelpableNumberActionMap(self, ["SetupActions", "DirectionActions", "ColorActions"], {
-			"ok": (self.save, _("Activate the currently selected skin")),
-			"cancel": (self.cancel, _("Revert to the currently active skin")),
-			"red": (self.cancel, _("Revert to the currently active skin")),
-			"green": (self.save, _("Activate the currently selected skin")),
-			"up": (self.up, _("Move to the previous skin")),
-			"down": (self.down, _("Move to the next skin")),
-			"left": (self.left, _("Move to the previous page")),
-			"right": (self.right, _("Move to the next page"))
-		}, -1, description=_("Skin Selection Actions"))
-		self.picload = ePicLoad()
-		self.picload.PictureData.get().append(self.showPic)
-		self.onLayoutFinish.append(self.layoutFinished)
-
-	def hackSkin(self):  # This is a hack to ensure the skin's SkinConverter screen works with the new code.
-		rescueSkin = """
+	skinTemplate = """
 	<screen name="SkinSelector" position="center,center" size="%d,%d">
 		<widget name="preview" position="center,%d" size="%d,%d" alphatest="blend" />
 		<widget source="skins" render="Listbox" position="center,%d" size="%d,%d" enableWrapAround="1" scrollbarMode="showOnDemand">
@@ -79,39 +38,84 @@ class SkinSelector(Screen, HelpableScreen):
 		<widget source="key_red" render="Label" position="%d,e-%d" size="%d,%d" backgroundColor="key_red" font="Regular;%d" foregroundColor="key_text" halign="center" valign="center" />
 		<widget source="key_green" render="Label" position="%d,e-%d" size="%d,%d" backgroundColor="key_green" font="Regular;%d" foregroundColor="key_text" halign="center" valign="center" />
 	</screen>"""
-		rescueData = [
-			670, 570,
-			10, 356, 200,
-			230, 650, 240,
-			10, 350, 30,
-			370, 260, 30,
-			25,
-			30,
-			490, 650, 25, 20,
-			10, 50, 140, 40, 20,
-			160, 50, 140, 40, 20
-		]
-		replaceSkin = False
+	scaleData = [
+		670, 570,
+		10, 356, 200,
+		230, 650, 240,
+		10, 350, 30,
+		370, 260, 30,
+		25,
+		30,
+		490, 650, 25, 20,
+		10, 50, 140, 40, 20,
+		160, 50, 140, 40, 20
+	]
+	skin = None
+
+	def __init__(self, session, menu_path="", screenTitle=_("GUI Skin")):
+		Screen.__init__(self, session)
+		HelpableScreen.__init__(self)
+		if SkinSelector.skin is None:
+			self.initialiseSkin()
+		if config.usage.show_menupath.value == 'large':
+			menu_path += screenTitle
+			title = menu_path
+			self["menu_path_compressed"] = StaticText("")
+		elif config.usage.show_menupath.value == 'small':
+			title = screenTitle
+			self["menu_path_compressed"] = StaticText(menu_path + " >" if not menu_path.endswith(" / ") else menu_path[:-3] + " >" or "")
+		else:
+			title = screenTitle
+			self["menu_path_compressed"] = StaticText("")
+		Screen.setTitle(self, title)
+		self.rootDir = resolveFilename(SCOPE_SKIN)
+		self.config = config.skin.primary_skin
+		self.current = currentPrimarySkin
+		self.xmlList = ["skin.xml"]
+		self.onChangedEntry = []
+		self["skins"] = List(enableWrapAround=True)
+		self["preview"] = Pixmap()
+		self["key_red"] = StaticText(_("Cancel"))
+		self["key_green"] = StaticText(_("Save"))
+		self["description"] = StaticText(_("Please wait... Loading list..."))
+		self["actions"] = HelpableNumberActionMap(self, ["SetupActions", "DirectionActions", "ColorActions"], {
+			"ok": (self.save, _("Save and activate the currently selected skin")),
+			"cancel": (self.cancel, _("Cancel any changes to the currently active skin")),
+			"close": (self.cancelRecursive, _("Cancel any changes to the currently active skin and exit all menus")),
+			"red": (self.cancel, _("Cancel any changes to the currently active skin")),
+			"green": (self.save, _("Save and activate the currently selected skin")),
+			"up": (self.up, _("Move to the previous skin")),
+			"down": (self.down, _("Move to the next skin")),
+			"left": (self.left, _("Move to the previous page")),
+			"right": (self.right, _("Move to the next page"))
+		}, -1, description=_("Skin Selection Actions"))
+		self.picload = ePicLoad()
+		self.picload.PictureData.get().append(self.showPic)
+		self.onLayoutFinish.append(self.layoutFinished)
+
+	def initialiseSkin(self):
 		element, path = domScreens.get("SkinSelector", (None, None))
-		if element is not None:
+		if element is None:  # This skin does not have a SkinConverter screen.
+			buildSkin = True
+		else:  # Test the skin's SkinConverter screen to ensure it works with the new code.
+			buildSkin = False
 			widgets = element.findall("widget")
 			if widgets is not None:
 				for widget in widgets:
 					name = widget.get("name", None)
-					if name == "Preview":
-						replaceSkin = True
-					if name == "SkinList":
-						replaceSkin = True
 					source = widget.get("source", None)
-					if source == "introduction":
-						replaceSkin = True
-		height = getDesktop(0).size().height()
-		if replaceSkin:
-			height = 720 if height < 720 else height
-			rescueData = [x * height / 720 for x in rescueData]
-			element = xml.etree.cElementTree.fromstring(rescueSkin % tuple(rescueData))
-			domScreens["SkinSelector"] = (element, path)
-		# print "[SkinSelector] DEBUG: Height=%d\n" % getDesktop(0).size().height(), xml.etree.cElementTree.tostring(element)
+					if name and name in ("Preview", "SkinList") or source == "introduction":
+						print "[SkinSelector] Warning: Current skin '%s' does not support this version of SkinSelector!    Please contact the skin's author!" % config.skin.primary_skin.value
+						del domScreens["SkinSelector"]  # It is incompatible, delete the screen from the skin.
+						buildSkin = True
+						break
+		if buildSkin:  # Build the embedded skin and scale it to the current screen resolution.
+			minRes = 720
+			height = max(minRes, getDesktop(0).size().height())
+			SkinSelector.skin = SkinSelector.skinTemplate % tuple([x * height / minRes for x in SkinSelector.scaleData])
+			# print "[SkinSelector] DEBUG: Height=%d\n" % height, SkinSelector.skin
+		else:
+			SkinSelector.skin = "<screen />"
 
 	def showPic(self, picInfo=""):
 		ptr = self.picload.getData()
@@ -170,10 +174,10 @@ class SkinSelector(Screen, HelpableScreen):
 						list = [dir, defaultPicon, dir, skin, resolution, preview]
 					else:
 						list = [dir, "", dir, skin, resolution, preview]
-					if skin == self.config.value:
-						list[1] = pending
 					if skin == self.current:
 						list[1] = current
+					elif skin == self.config.value:
+						list[1] = pending
 					# 0=SortKey, 1=Label, 2=Flag, 3=Directory, 4=Skin, 5=Resolution, 6=Preview
 					skinList.append(tuple([list[0].upper()] + list))
 		skinList.sort()
@@ -199,16 +203,30 @@ class SkinSelector(Screen, HelpableScreen):
 			self["description"].setText(_("Press OK to activate the selected%s skin.") % msg)
 
 	def cancel(self):
-		self.close()
+		self.close(False)
+
+	def cancelRecursive(self):
+		self.close(True)
 
 	def save(self):
+		label = self["skins"].getCurrent()[1]
 		skin = self["skins"].getCurrent()[4]
-		if self.config.value == skin:
-			print "[SkinSelector] Selected skin: '%s' (Unchanged!)" % pathjoin(self.rootDir, skin)
+		if skin == self.config.value:
+			if skin == self.current:
+				print "[SkinSelector] Selected skin: '%s' (Unchanged!)" % pathjoin(self.rootDir, skin)
+				self.cancel()
+			else:
+				print "[SkinSelector] Selected skin: '%s' (Trying to restart again!)" % pathjoin(self.rootDir, skin)
+				restartBox = self.session.openWithCallback(self.restartGUI, MessageBox, _("To apply the selected '%s' skin the GUI needs to restart.  Would you like to restart the GUI now?" % label), MessageBox.TYPE_YESNO)
+				restartBox.setTitle(_("SkinSelector: Restart GUI"))
+		elif skin == self.current:
+			print "[SkinSelector] Selected skin: '%s' (Pending skin '%s' cancelled!)" % (pathjoin(self.rootDir, skin), pathjoin(self.rootDir, self.config.value))
+			self.config.value = skin
+			self.config.save()
 			self.cancel()
 		else:
 			print "[SkinSelector] Selected skin: '%s'" % pathjoin(self.rootDir, skin)
-			restartBox = self.session.openWithCallback(self.restartGUI, MessageBox, _("To save and apply the selected '%s' skin the GUI needs to restart.  Would you like to save the selection and restart the GUI?" % self["skins"].getCurrent()[1]), MessageBox.TYPE_YESNO)
+			restartBox = self.session.openWithCallback(self.restartGUI, MessageBox, _("To save and apply the selected '%s' skin the GUI needs to restart.  Would you like to save the selection and restart the GUI now?" % label), MessageBox.TYPE_YESNO)
 			restartBox.setTitle(_("SkinSelector: Restart GUI"))
 
 	def restartGUI(self, answer):


### PR DESCRIPTION
- Evolve the skin hack that checks if the existing screen is valid into an embedded skin.
- Only test if the existing screen requires replacement once.
- Build the embedded skin once and only if it is required.
- Optimise some more code logic.
- Improve the text in some of the user dialogues and help.
- If the user selects the current skin when there is a pending skin change on restart the restart is cleared.
- If a skin update is pending because a restart was rejected then try the restart again on the next save.
