### PR TITLE
Add geolocation to Timezones.py

### DIFF
--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -6,37 +6,42 @@ from enigma import eTimer
 from os import environ, path, symlink, unlink, walk
 
 from Components.config import ConfigSelection, ConfigSubsection, config
+from Tools.Geolocation import geolocation
 from Tools.StbHardware import setRTCoffset
 
 # The DEFAULT_AREA setting is usable by the image maintainers to select the
-# default mode and location used by their image.  If the value of "Classic"
-# is used then Beyonwiz and OpenViX will have the "Timezone area" set to
-# "Classic" and the "Timezone" field will be an expanded version of the
-# classic list of GMT related offsets.  Both OpenATV and OpenPLi should
-# use "Classic" to maintain their chosen UI for timezone selection.  That
-# is, OpenATV and OpenPLi do not offer the "Timezone area" selector and
-# they rely on the "Timezone" selector to select a GMT offset option.
+# default UI mode and location settings used by their image.  If the value
+# of "Classic" is used then images that use the "Timezone area" and 
+# "Timezone" settings will have the "Timezone area" set to "Classic" and the
+# "Timezone" field will be an expanded version of the classic list of GMT
+# related offsets.  Images that only use the "Timezone" setting should use
+# "Classic" to maintain their chosen UI for timezone selection.  That is,
+# users will only be presented with the list of GMT related offsets.
 #
 # The DEFAULT_ZONE is used to select the default timezone if the "Timezone
 # area" is selected to be "Europe".  This allows OpenViX to have the
-# European default of "London" while OpenATV can select "Berlin", etc.
-# These are only suggestions.  Images can select any defaults they deem
+# European default of "London" while OpenATV and OpenPLi can select "Berlin",
+# etc. (These are only examples.)  Images can select any defaults they deem
 # appropriate.
 #
 # NOTE: Even if the DEFAULT_AREA of "Classic" is selected a DEFAULT_ZONE
 # must still be selected.
 #
 # For images that use both the "Timezone area" and "Timezone" configuration
-# options (currently Beyonwiz and OpenViX) then the DEFAULT_AREA can be set
-# to an area most appropriate for the image.  For Beyonwiz that would be
-# "Australia", OpenATV, OpenViX and OpenPLi would use "Europe".  If the
-# "Europe" option is selected then the DEFAULT_ZONE can be used to select a
-# more appropriate timezone selection for the image.  I believe that
-# OpenATV and possibly OpenPLi may prefer "Berlin" while OpenViX may
-# prefer "London".
+# options then the DEFAULT_AREA can be set to an area most appropriate for
+# the image.  For example, Beyonwiz would use "Australia", OpenATV, OpenViX
+# and OpenPLi would use "Europe".  If the "Europe" option is selected then
+# the DEFAULT_ZONE can be used to select a more appropriate timezone 
+# selection for the image.  For example, OpenATV and OpenPLi may prefer
+# "Berlin" while OpenViX may prefer "London".
 #
 # Please ensure that any defaults selected are valid, unique and available
 # in the "/usr/share/zoneinfo/" directory tree.
+#
+# This version of Timezones.py now incorporates access to a new Geolocation
+# feature that will try and determine the appropriate timezone for the user
+# based on their WAN IP address.  If the receiver is not connected to the
+# Internet the defaults described above and listed below will be used.
 #
 # DEFAULT_AREA = "Classic"  # Use the classic timezone based list of timezones.
 # DEFAULT_AREA = "Australia"  # Beyonwiz
@@ -48,17 +53,32 @@ TIMEZONE_DATA = "/usr/share/zoneinfo/"  # This should be SCOPE_TIMEZONES_DATA!
 AT_POLL_DELAY = 3  # Minutes
 
 def InitTimeZones():
+	tz = geolocation.get("timezone", None)
+	if tz is None:
+		area = DEFAULT_AREA
+		zone = timezones.getTimezoneDefault()
+		print "[Timezones] Geolocation not available!  (area='%s', zone='%s')" % (area, zone)
+	elif DEFAULT_AREA == "Classic":
+		area = "Classic"
+		zone = tz
+		print "[Timezones] Classic mode with geolocation tz='%s', area='%s', zone='%s'." % (tz, area, zone)
+	else:
+		area, zone = tz.split("/", 1)
+		print "[Timezones] Modern mode with geolocation tz='%s', area='%s', zone='%s'." % (tz, area, zone)
 	config.timezone = ConfigSubsection()
-	config.timezone.area = ConfigSelection(default=DEFAULT_AREA, choices=timezones.getTimezoneAreaList())
+	config.timezone.area = ConfigSelection(default=area, choices=timezones.getTimezoneAreaList())
 	config.timezone.val = ConfigSelection(default=timezones.getTimezoneDefault(), choices=timezones.getTimezoneList())
+	if not config.timezone.area.saved_value:
+		config.timezone.area.value = area
+	if not config.timezone.val.saved_value:
+		config.timezone.val.value = zone
+	config.timezone.save()
 
 	def timezoneAreaChoices(configElement):
 		choices = timezones.getTimezoneList(area=configElement.value)
+		config.timezone.val.setChoices(choices=choices, default=timezones.getTimezoneDefault(area=configElement.value, choices=choices))
 		if config.timezone.val.saved_value and config.timezone.val.saved_value in [x[0] for x in choices]:
-			default = config.timezone.val.saved_value
-		else:
-			default = timezones.getTimezoneDefault(area=configElement.value, choices=choices)
-		config.timezone.val.setChoices(choices=choices, default=default)
+			config.timezone.val.value = config.timezone.val.saved_value
 
 	def timezoneNotifier(configElement):
 		timezones.activateTimezone(configElement.value, config.timezone.area.value)
@@ -83,6 +103,7 @@ class Timezones:
 	#
 	def loadTimezones(self):
 		commonTimezoneNames = {
+			"Antarctica/DumontDUrville": "Dumont d'Urville",
 			"Asia/Ho_Chi_Minh": "Ho Chi Minh City",
 			"Australia/LHI": None,  # Exclude
 			"Australia/Lord_Howe": "Lord Howe Island",
@@ -103,6 +124,8 @@ class Timezones:
 		}
 		for (root, dirs, files) in walk(TIMEZONE_DATA):
 			base = root[len(TIMEZONE_DATA):]
+			if base in ("posix", "right"):  # Skip these alternate copies of the timezone data if they exist.
+				continue
 			if base == "":
 				base = "Generic"
 			area = None
@@ -216,7 +239,7 @@ class Timezones:
 		return areaDefaultZone.setdefault(area, choices[0][0])
 
 	def activateTimezone(self, zone, area):
-		print "[Timezones] activateTimezone DEBUG: Area='%s', Zone='%s'" % (area, zone)
+		# print "[Timezones] activateTimezone DEBUG: Area='%s', Zone='%s'" % (area, zone)
 		self.autotimerCheck()
 		if self.autotimerAvailable and config.plugins.autotimer.autopoll.value:
 			print "[Timezones] Trying to stop main AutoTimer poller."

--- a/lib/python/Tools/Geolocation.py
+++ b/lib/python/Tools/Geolocation.py
@@ -1,0 +1,64 @@
+from json import loads
+from urllib2 import URLError, urlopen
+
+# Data available from http://ip-api.com/json/:
+#
+# 	Name		Description				Example			Type
+# 	--------------	--------------------------------------	----------------------	------
+# 	status		success or fail				success			string
+# 	message		Included only when status is fail. Can
+# 			be one of the following: private range,
+# 			reserved range, invalid query		invalid query		string
+# 	continent	Continent name				North America		string
+# 	continentCode	Two-letter continent code		NA			string
+# 	country		Country name				United States		string
+# 	countryCode	Two-letter country code
+# 			ISO 3166-1 alpha-2			US			string
+# 	region		Region/state short code (FIPS or ISO)	CA or 10		string
+# 	regionName	Region/state				California		string
+# 	city		City					Mountain View		string
+# 	district	District (subdivision of city)		Old Farm District	string
+# 	zip		Zip code				94043			string
+# 	lat		Latitude				37.4192			float
+# 	lon		Longitude				-122.0574		float
+# 	timezone	City timezone				America/Los_Angeles	string
+# 	currency	National currency			USD			string
+# 	isp		ISP name				Google			string
+# 	org		Organization name			Google			string
+# 	as		AS number and organization, separated
+# 			by space (RIR). Empty for IP blocks 
+# 			not being announced in BGP tables.	AS15169 Google Inc.	string
+# 	asname		AS name (RIR). Empty for IP blocks not
+# 			being announced in BGP tables.		GOOGLE			string
+# 	reverse		Reverse DNS of the IP
+# 			(Not fetched as it delays response)	wi-in-f94.1e100.net	string
+# 	mobile		Mobile (cellular) connection		true			bool
+# 	proxy		Proxy, VPN or Tor exit address		true			bool
+# 	hosting		Hosting, colocated or data center	true			bool
+# 	query		IP used for the query			173.194.67.94		string
+
+geolocation = {}
+
+def InitGeolocation():
+	global geolocation
+	if len(geolocation) == 0:
+		try:
+			response = urlopen("http://ip-api.com/json/?fields=33288191", data=None, timeout=10).read()
+			# print "[Geolocation] DEBUG:", response
+			if response:
+				geolocation = loads(response)
+			status = geolocation.get("status", None)
+			if status and status == "success":
+				print "[Geolocation] Geolocation data initialised."
+			else:
+				print "[Geolocation] Error: Geolocation lookup returned a '%s' status!  Message '%s' returned." % (status, geolocation.get("message", None))
+		except URLError as err:
+			if hasattr(err, 'code'):
+				print "[Geolocation] Error : Geolocation data not available! (Code: %s)" % err.code
+			if hasattr(err, 'reason'):
+				print "[Geolocation] Error : Geolocation data not available! (Reason: %s)" % err.reason
+
+def RefreshGeolocation():
+	global geolocation
+	geolocation = {}
+	InitGeolocation()

--- a/mytest.py
+++ b/mytest.py
@@ -32,6 +32,10 @@ if getImageArch() in ("aarch64"):
 
 from traceback import print_exc
 
+profile("Geolocation")
+import Tools.Geolocation
+Tools.Geolocation.InitGeolocation()
+
 profile("ClientMode")
 import Components.ClientMode
 Components.ClientMode.InitClientMode()


### PR DESCRIPTION
- [Timezones.py] Add geolocation and enhancements
  - Add access to geolocation data to establish the initial guess of the user's timezone.
  - Don't change the default timezone when navigating through available timezone lists.
  - Ignore the existence of alternate txdata from "posix" or "right" packages.
  - Improve the configuration comments.
  - Comment out some debugging logs.
  - Correct name display of "Dumont d'Urville".

- [Geolocation.py] New tool to provide geolocation data

- [mytest.py] Activate geolocation initialisation
