### PR TITLE
[Timezones.py] Resolve boot loop with no network

### DIFF
--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -56,7 +56,7 @@ def InitTimeZones():
 	tz = geolocation.get("timezone", None)
 	if tz is None:
 		area = DEFAULT_AREA
-		zone = timezones.getTimezoneDefault()
+		zone = timezones.getTimezoneDefault(area=area)
 		print "[Timezones] Geolocation not available!  (area='%s', zone='%s')" % (area, zone)
 	elif DEFAULT_AREA == "Classic":
 		area = "Classic"


### PR DESCRIPTION
If no network is available use the current working value of the "area" to avoid a boot loop trying to use an "area" definition in the "config" dictionary that has not yet been created.
