### PR TITLE
[Harddisk.py] Correct inappropriate log errors

### DIFF
--- a/lib/python/Components/Harddisk.py
+++ b/lib/python/Components/Harddisk.py
@@ -720,7 +720,7 @@ class HarddiskManager:
 			except OSError:
 				physdev = dev
 				print "[Harddisk] couldn't determine blockdev physdev for device", device
-		error, blacklisted, removable, is_cdrom, partitions, medium_found = self.getBlockDevInfo(self.splitDeviceName(device)[0])
+		error, blacklisted, removable, is_cdrom, partitions, medium_found = self.getBlockDevInfo(device)
 
 		if not blacklisted and medium_found:
 			description = self.getUserfriendlyDeviceName(device, physdev)


### PR DESCRIPTION
An incorrect device name was being passed into the "getBlockDevInfo()" method resulting in many "[Harddisk] couldn't read model:" errors being logged.
