### PR TITLE
[mytest.py] Fix boot loop / crash

### DIFF
--- a/mytest.py
+++ b/mytest.py
@@ -613,10 +613,6 @@ import Components.InputDevice
 Components.InputDevice.InitInputDevices()
 import Components.InputHotplug
 
-profile("TimeZones")
-import Components.Timezones
-Components.Timezones.InitTimeZones()
-
 profile("SetupDevices")
 import Components.SetupDevices
 Components.SetupDevices.InitSetupDevices()
@@ -637,6 +633,10 @@ Components.RecordingConfig.InitRecordingConfig()
 profile("UsageConfig")
 import Components.UsageConfig
 Components.UsageConfig.InitUsageConfig()
+
+profile("TimeZones")
+import Components.Timezones
+Components.Timezones.InitTimeZones()
 
 profile("Init:DebugLogCheck")
 import Screens.LogManager


### PR DESCRIPTION
Some receivers have an issue with the new Timezones.py code causing a crash / boot loop in StbHardware.py.  The problem is that on some receivers the UsageConfig.py is already initialised and on others it isn't.  This fix is to move the Timezones.py initialisation until after the UsageConfig.py is formally initialised.
