### PR TITLE
[Timezones.py] Changes for legacy support

### DIFF
--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -163,11 +163,14 @@ class Timezones:
 				tz = "%s/%s" % (base, file)
 				area, zone = tz.split("/", 1)
 				name = commonTimezoneNames.get(tz, zone)  # Use the more common name if one is defined.
-				area = area.encode(encoding="UTF-8", errors="ignore")
-				zone = zone.encode(encoding="UTF-8", errors="ignore")
 				if name is None:
 					continue
-				name = name.encode(encoding="UTF-8", errors="ignore")
+				if isinstance(name, unicode):
+					name = name.encode(encoding="UTF-8", errors="ignore")
+				if isinstance(area, unicode):
+					area = area.encode(encoding="UTF-8", errors="ignore")
+				if isinstance(zone, unicode):
+					zone = zone.encode(encoding="UTF-8", errors="ignore")
 				zones.append((zone, name.replace("_", " ")))
 			if area:
 				if area in self.timezones:
@@ -228,9 +231,11 @@ class Timezones:
 		if root is not None:
 			for zone in root.findall("zone"):
 				name = zone.get("name", "")
+				if isinstance(name, unicode):
+					name = name.encode(encoding="UTF-8", errors="ignore")
 				zonePath = zone.get("zone", "")
-				name = name.encode(encoding="UTF-8", errors="ignore")
-				zonePath = zonePath.encode(encoding="UTF-8", errors="ignore")
+				if isinstance(zonePath, unicode):
+					zonePath = zonePath.encode(encoding="UTF-8", errors="ignore")
 				if path.exists(path.join(TIMEZONE_DATA, zonePath)):
 					zones.append((zonePath, name))
 				else:

--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -76,20 +76,25 @@ def InitTimeZones():
 		config.timezone.area.value = "Generic"
 	try:
 		tzLink = path.realpath("/etc/localtime")[20:]
-		tzSplit = tzLink.find("/")
-		if tzSplit == -1:
-			tzArea = "Generic"
-			tzVal = tzLink
-		else:
-			tzArea = tzLink[:tzSplit]
-			tzVal = tzLink[tzSplit + 1:]
 		msgs = []
-		if config.timezone.area.value != tzArea:
-			msgs.append("area '%s' != '%s'" % (tzArea, config.timezone.area.value))
-			config.timezone.area.value = tzArea
-		if config.timezone.val.value != tzVal:
-			msgs.append("zone '%s' != '%s'" % (tzVal, config.timezone.val.value))
-			config.timezone.val.value = tzVal
+		if config.timezone.area.value == "Classic":
+			if config.timezone.val.value != tzLink:
+				msgs.append("time zone '%s' != '%s'" % (tzLink, config.timezone.val.value))
+				config.timezone.val.value = tzLink
+		else:
+			tzSplit = tzLink.find("/")
+			if tzSplit == -1:
+				tzArea = "Generic"
+				tzVal = tzLink
+			else:
+				tzArea = tzLink[:tzSplit]
+				tzVal = tzLink[tzSplit + 1:]
+			if config.timezone.area.value != tzArea:
+				msgs.append("area '%s' != '%s'" % (tzArea, config.timezone.area.value))
+				config.timezone.area.value = tzArea
+			if config.timezone.val.value != tzVal:
+				msgs.append("zone '%s' != '%s'" % (tzVal, config.timezone.val.value))
+				config.timezone.val.value = tzVal
 		if len(msgs):
 			print "[Timezones] Warning: System timezone does not match Enigma2 timezone (%s), setting Enigma2 to system timezone!" % ",".join(msgs)
 	except (IOError, OSError):
@@ -146,7 +151,7 @@ class Timezones:
 		}
 		for (root, dirs, files) in walk(TIMEZONE_DATA):
 			base = root[len(TIMEZONE_DATA):]
-			if base in ("posix", "right"):  # Skip these alternate copies of the timezone data if they exist.
+			if base.startswith("posix") or base.startswith("right"):  # Skip these alternate copies of the timezone data if they exist.
 				continue
 			if base == "":
 				base = "Generic"
@@ -274,18 +279,18 @@ class Timezones:
 			tz = "UTC"
 			file = path.join(TIMEZONE_DATA, tz)
 		print "[Timezones] Setting timezone to '%s'." % tz
-		environ["TZ"] = tz
 		try:
 			unlink("/etc/localtime")
 		except (IOError, OSError) as err:
 			if err.errno != errno.ENOENT:  # No such file or directory
-				print "[Directories] Error %d: Unlinking '/etc/localtime'! (%s)" % (err.errno, err.strerror)
+				print "[Timezones] Error %d: Unlinking '/etc/localtime'! (%s)" % (err.errno, err.strerror)
 			pass
 		try:
 			symlink(file, "/etc/localtime")
 		except (IOError, OSError) as err:
-			print "[Directories] Error %d: Linking '%s' to '/etc/localtime'! (%s)" % (err.errno, file, err.strerror)
+			print "[Timezones] Error %d: Linking '%s' to '/etc/localtime'! (%s)" % (err.errno, file, err.strerror)
 			pass
+		environ["TZ"] = ":%s" % tz
 		try:
 			time.tzset()
 		except Exception:

--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -45,7 +45,8 @@ from Tools.StbHardware import setRTCoffset
 # DEFAULT_AREA = "Classic"  # Use the classic timezone based list of timezones.
 # DEFAULT_AREA = "Australia"  # Beyonwiz
 DEFAULT_AREA = "Europe"  # OpenATV, OpenPLi, OpenViX
-# DEFAULT_ZONE = "Berlin"  # OpenATV, OpenPLi
+# DEFAULT_ZONE = "Amsterdam"  # OpenPLi
+# DEFAULT_ZONE = "Berlin"  # OpenATV
 DEFAULT_ZONE = "London"  # OpenViX
 TIMEZONE_FILE = "/etc/timezone.xml"  # This should be SCOPE_TIMEZONES_FILE!  This file moves arond the filesystem!!!  :(
 TIMEZONE_DATA = "/usr/share/zoneinfo/"  # This should be SCOPE_TIMEZONES_DATA!
@@ -64,13 +65,35 @@ def InitTimeZones():
 	elif DEFAULT_AREA == "Classic":
 		area = "Classic"
 		zone = tz
-		print "[Timezones] Classic mode with geolocation tz='%s', area='%s', zone='%s'." % (tz, area, zone)
+		print "[Timezones] Classic mode with geolocation tz='%s'.  (area='%s', zone='%s')" % (tz, area, zone)
 	else:
 		area, zone = tz.split("/", 1)
-		print "[Timezones] Modern mode with geolocation tz='%s', area='%s', zone='%s'." % (tz, area, zone)
+		print "[Timezones] Modern mode with geolocation tz='%s'.  (area='%s', zone='%s')" % (tz, area, zone)
 	config.timezone = ConfigSubsection()
 	config.timezone.area = ConfigSelection(default=area, choices=timezones.getTimezoneAreaList())
 	config.timezone.val = ConfigSelection(default=timezones.getTimezoneDefault(), choices=timezones.getTimezoneList())
+	if not config.timezone.area.value and config.timezone.val.value.find("/") == -1:
+		config.timezone.area.value = "Generic"
+	try:
+		tzLink = path.realpath("/etc/localtime")[20:]
+		tzSplit = tzLink.find("/")
+		if tzSplit == -1:
+			tzArea = "Generic"
+			tzVal = tzLink
+		else:
+			tzArea = tzLink[:tzSplit]
+			tzVal = tzLink[tzSplit + 1:]
+		msgs = []
+		if config.timezone.area.value != tzArea:
+			msgs.append("area '%s' != '%s'" % (tzArea, config.timezone.area.value))
+			config.timezone.area.value = tzArea
+		if config.timezone.val.value != tzVal:
+			msgs.append("zone '%s' != '%s'" % (tzVal, config.timezone.val.value))
+			config.timezone.val.value = tzVal
+		if len(msgs):
+			print "[Timezones] Warning: System timezone does not match Enigma2 timezone (%s), setting Enigma2 to system timezone!" % ",".join(msgs)
+	except (IOError, OSError):
+		pass
 
 	def timezoneAreaChoices(configElement):
 		choices = timezones.getTimezoneList(area=configElement.value)

--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -79,8 +79,8 @@ def InitTimeZones():
 		msgs = []
 		if config.timezone.area.value == "Classic":
 			if config.timezone.val.value != tzLink:
-				msgs.append("time zone '%s' != '%s'" % (tzLink, config.timezone.val.value))
-				config.timezone.val.value = tzLink
+				msgs.append("time zone '%s' != '%s'" % (config.timezone.val.value, tzLink))
+				# config.timezone.val.value = tzLink
 		else:
 			tzSplit = tzLink.find("/")
 			if tzSplit == -1:
@@ -90,13 +90,14 @@ def InitTimeZones():
 				tzArea = tzLink[:tzSplit]
 				tzVal = tzLink[tzSplit + 1:]
 			if config.timezone.area.value != tzArea:
-				msgs.append("area '%s' != '%s'" % (tzArea, config.timezone.area.value))
-				config.timezone.area.value = tzArea
+				msgs.append("area '%s' != '%s'" % (config.timezone.area.value, tzArea))
+				# config.timezone.area.value = tzArea
 			if config.timezone.val.value != tzVal:
-				msgs.append("zone '%s' != '%s'" % (tzVal, config.timezone.val.value))
-				config.timezone.val.value = tzVal
+				msgs.append("zone '%s' != '%s'" % (config.timezone.val.value, tzVal))
+				# config.timezone.val.value = tzVal
 		if len(msgs):
-			print "[Timezones] Warning: System timezone does not match Enigma2 timezone (%s), setting Enigma2 to system timezone!" % ",".join(msgs)
+			# print "[Timezones] Warning: Enigma2 time zone does not match system time zone (%s), setting Enigma2 to system time zone!" % ",".join(msgs)
+			print "[Timezones] Warning: Enigma2 time zone does not match system time zone (%s), setting system to Enigma2 time zone!" % ",".join(msgs)
 	except (IOError, OSError):
 		pass
 


### PR DESCRIPTION
[Timezones.py] Changes for legacy support
- Add a new DEFAULT_ZONE = "Amsterdam" for OpenPLi.
- Load and use the timezone in "/etc/localtime" if it differs from the timezone defined in Enigma2.  A warning is logged if the timezones differ.
- Improve some of the logging messages.

[Timezones.py] Multiple fixes
- Fix initialisation in "Classic" mode.
- Fix "posix" and "right" zoneinfo files not being properly suppressed.
- Fix the value of the "TZ" shell variable.
- Fix logging messages referring to "Directories".

[Timezones.py] Optimise string encoding
- Only encode strings that actually contain UTF-8 characters.

[Timezones.py] Make settings time zone dominant
- This change allows the time zone in the "settings" file to override the "/etc/localtime" time zone setting.  This will allow users to restore their "settings" file from a backup and have the Linux, glib, TZ and Enigma2 time zones all be matched.
