### PR TITLE
More time zone code clean up

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -2,8 +2,8 @@
 <!-- "titleshort" attribute is optional. If present it will be used as the item title in the menu. It will also be used as the header in setup screens when menu path is enabled. -->
 <setupxml>
 	<setup key="time" title="Time">
-		<item level="0" text="Timezone area" description="Setup your timezone area.">config.timezone.area</item>
-		<item level="0" text="Timezone" description="Your timezone in the area.">config.timezone.val</item>
+		<item level="0" text="Time zone area" description="Select your time zone area or region.">config.timezone.area</item>
+		<item level="0" text="Time zone" description="Select the time zone within the area or region.">config.timezone.val</item>
 		<item level="0" text="Sync time using" description="Synchronize system time using transponder or internet.">config.misc.SyncTimeUsing</item>
 		<item level="0" text="NTP server" description="Configure your NTP server.">config.misc.NTPserver</item>
 		<item level="0" text="Sync NTP every (minutes)" description="Setup network time synchronization interval." requires="config.misc.SyncTimeUsing" >config.misc.useNTPminutes</item>

--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -283,18 +283,15 @@ class Timezones:
 		except (IOError, OSError) as err:
 			if err.errno != errno.ENOENT:  # No such file or directory
 				print "[Timezones] Error %d: Unlinking '/etc/localtime'! (%s)" % (err.errno, err.strerror)
-			pass
 		try:
 			symlink(file, "/etc/localtime")
 		except (IOError, OSError) as err:
 			print "[Timezones] Error %d: Linking '%s' to '/etc/localtime'! (%s)" % (err.errno, file, err.strerror)
-			pass
 		try:
 			with open("/etc/timezone", "w") as fd:
 				fd.write("%s\n" % tz)
 		except (IOError, OSError) as err:
 			print "[Timezones] Error %d: Updating '/etc/timezone'! (%s)" % (err.errno, err.strerror)
-			pass
 		environ["TZ"] = ":%s" % tz
 		try:
 			time.tzset()

--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -10,14 +10,14 @@ from Tools.StbHardware import setRTCoffset
 
 # The DEFAULT_AREA setting is usable by the image maintainers to select the
 # default UI mode and location settings used by their image.  If the value
-# of "Classic" is used then images that use the "Timezone area" and
-# "Timezone" settings will have the "Timezone area" set to "Classic" and the
-# "Timezone" field will be an expanded version of the classic list of GMT
-# related offsets.  Images that only use the "Timezone" setting should use
-# "Classic" to maintain their chosen UI for timezone selection.  That is,
+# of "Classic" is used then images that use the "Time zone area" and
+# "Time zone" settings will have the "Time zone area" set to "Classic" and the
+# "Time zone" field will be an expanded version of the classic list of GMT
+# related offsets.  Images that only use the "Time zone" setting should use
+# "Classic" to maintain their chosen UI for time zone selection.  That is,
 # users will only be presented with the list of GMT related offsets.
 #
-# The DEFAULT_ZONE is used to select the default timezone if the "Timezone
+# The DEFAULT_ZONE is used to select the default time zone if the "Time zone
 # area" is selected to be "Europe".  This allows OpenViX to have the
 # European default of "London" while OpenATV and OpenPLi can select "Berlin",
 # etc. (These are only examples.)  Images can select any defaults they deem
@@ -26,11 +26,11 @@ from Tools.StbHardware import setRTCoffset
 # NOTE: Even if the DEFAULT_AREA of "Classic" is selected a DEFAULT_ZONE
 # must still be selected.
 #
-# For images that use both the "Timezone area" and "Timezone" configuration
+# For images that use both the "Time zone area" and "Time zone" configuration
 # options then the DEFAULT_AREA can be set to an area most appropriate for
 # the image.  For example, Beyonwiz would use "Australia", OpenATV, OpenViX
 # and OpenPLi would use "Europe".  If the "Europe" option is selected then
-# the DEFAULT_ZONE can be used to select a more appropriate timezone
+# the DEFAULT_ZONE can be used to select a more appropriate time zone
 # selection for the image.  For example, OpenATV and OpenPLi may prefer
 # "Berlin" while OpenViX may prefer "London".
 #
@@ -38,11 +38,11 @@ from Tools.StbHardware import setRTCoffset
 # in the "/usr/share/zoneinfo/" directory tree.
 #
 # This version of Timezones.py now incorporates access to a new Geolocation
-# feature that will try and determine the appropriate timezone for the user
+# feature that will try and determine the appropriate time zone for the user
 # based on their WAN IP address.  If the receiver is not connected to the
 # Internet the defaults described above and listed below will be used.
 #
-# DEFAULT_AREA = "Classic"  # Use the classic timezone based list of timezones.
+# DEFAULT_AREA = "Classic"  # Use the classic time zone based list of time zones.
 # DEFAULT_AREA = "Australia"  # Beyonwiz
 DEFAULT_AREA = "Europe"  # OpenATV, OpenPLi, OpenViX
 # DEFAULT_ZONE = "Amsterdam"  # OpenPLi
@@ -80,7 +80,6 @@ def InitTimeZones():
 		if config.timezone.area.value == "Classic":
 			if config.timezone.val.value != tzLink:
 				msgs.append("time zone '%s' != '%s'" % (config.timezone.val.value, tzLink))
-				# config.timezone.val.value = tzLink
 		else:
 			tzSplit = tzLink.find("/")
 			if tzSplit == -1:
@@ -91,12 +90,9 @@ def InitTimeZones():
 				tzVal = tzLink[tzSplit + 1:]
 			if config.timezone.area.value != tzArea:
 				msgs.append("area '%s' != '%s'" % (config.timezone.area.value, tzArea))
-				# config.timezone.area.value = tzArea
 			if config.timezone.val.value != tzVal:
 				msgs.append("zone '%s' != '%s'" % (config.timezone.val.value, tzVal))
-				# config.timezone.val.value = tzVal
 		if len(msgs):
-			# print "[Timezones] Warning: Enigma2 time zone does not match system time zone (%s), setting Enigma2 to system time zone!" % ",".join(msgs)
 			print "[Timezones] Warning: Enigma2 time zone does not match system time zone (%s), setting system to Enigma2 time zone!" % ",".join(msgs)
 	except (IOError, OSError):
 		pass
@@ -127,13 +123,13 @@ class Timezones:
 		# code should be removed from the Timezones.py code!
 		self.autotimerInit()
 
-	# Scan the zoneinfo directory tree and all load all timezones found.
+	# Scan the zoneinfo directory tree and all load all time zones found.
 	#
 	def loadTimezones(self):
 		commonTimezoneNames = {
 			"Antarctica/DumontDUrville": "Dumont d'Urville",
 			"Asia/Ho_Chi_Minh": "Ho Chi Minh City",
-			"Australia/LHI": None,  # Exclude
+			"Australia/LHI": None,  # Duplicate entry - Exclude from list.
 			"Australia/Lord_Howe": "Lord Howe Island",
 			"Australia/North": "Northern Territory",
 			"Australia/South": "South Australia",
@@ -152,7 +148,7 @@ class Timezones:
 		}
 		for (root, dirs, files) in walk(TIMEZONE_DATA):
 			base = root[len(TIMEZONE_DATA):]
-			if base.startswith("posix") or base.startswith("right"):  # Skip these alternate copies of the timezone data if they exist.
+			if base.startswith("posix") or base.startswith("right"):  # Skip these alternate copies of the time zone data if they exist.
 				continue
 			if base == "":
 				base = "Generic"
@@ -200,13 +196,12 @@ class Timezones:
 			data[key] = (zone, name)
 		return [data[x] for x in sorted(data.keys())]
 
-	# Read the timezones.xml file and load all timezones found.
+	# Read the timezones.xml file and load all time zones found.
 	#
 	def readTimezones(self, filename=TIMEZONE_FILE):
 		root = None
 		try:
-			# This open gets around a possible file handle leak in Python's XML parser.
-			with open(filename, "r") as fd:
+			with open(filename, "r") as fd:  # This open gets around a possible file handle leak in Python's XML parser.
 				try:
 					root = xml.etree.cElementTree.parse(fd).getroot()
 				except xml.etree.cElementTree.ParseError as err:
@@ -220,14 +215,14 @@ class Timezones:
 					print "[Timezones] XML Parse Error: '%s^%s'" % ("-" * column, " " * (len(data) - column - 1))
 				except Exception as err:
 					root = None
-					print "[Timezones] Error: Unable to parse timezone data in '%s' - '%s'!" % (filename, err)
+					print "[Timezones] Error: Unable to parse time zone data in '%s' - '%s'!" % (filename, err)
 		except (IOError, OSError) as err:
 			if err.errno == errno.ENOENT:  # No such file or directory
-				print "[Timezones] Note: Classic timezones in '%s' are not available." % filename
+				print "[Timezones] Note: Classic time zones in '%s' are not available." % filename
 			else:
-				print "[Timezones] Error %d: Opening timezone file '%s'! (%s)" % (err.errno, filename, err.strerror)
+				print "[Timezones] Error %d: Opening time zone file '%s'! (%s)" % (err.errno, filename, err.strerror)
 		except Exception as err:
-			print "[Timezones] Error: Unexpected error opening timezone file '%s'! (%s)" % (filename, err)
+			print "[Timezones] Error: Unexpected error opening time zone file '%s'! (%s)" % (filename, err)
 		zones = []
 		if root is not None:
 			for zone in root.findall("zone"):
@@ -240,8 +235,7 @@ class Timezones:
 				if path.exists(path.join(TIMEZONE_DATA, zonePath)):
 					zones.append((zonePath, name))
 				else:
-					print "[Timezones] Warning: Classic timezone '%s' (%s) is not available in '%s'!" % (name, zonePath, TIMEZONE_DATA)
-				# print "[Timezones] DEBUG: Count=%2d, Name='%-50s', Zone='%s'%s" % (len(zones), name, zonePath)
+					print "[Timezones] Warning: Classic time zone '%s' (%s) is not available in '%s'!" % (name, zonePath, TIMEZONE_DATA)
 			self.timezones["Classic"] = zones
 		if len(zones) == 0:
 			self.timezones["Classic"] = [("UTC", "UTC")]
@@ -277,14 +271,13 @@ class Timezones:
 		return areaDefaultZone.setdefault(area, choices[0][0])
 
 	def activateTimezone(self, zone, area, runCallbacks=True):
-		# print "[Timezones] activateTimezone DEBUG: Area='%s', Zone='%s'" % (area, zone)
 		tz = zone if area in ("Classic", "Generic") else path.join(area, zone)
 		file = path.join(TIMEZONE_DATA, tz)
 		if not path.isfile(file):
-			print "[Timezones] Error: The timezone '%s' is not available!  Using 'UTC' instead." % tz
+			print "[Timezones] Error: The time zone '%s' is not available!  Using 'UTC' instead." % tz
 			tz = "UTC"
 			file = path.join(TIMEZONE_DATA, tz)
-		print "[Timezones] Setting timezone to '%s'." % tz
+		print "[Timezones] Setting time zone to '%s'." % tz
 		try:
 			unlink("/etc/localtime")
 		except (IOError, OSError) as err:
@@ -295,6 +288,12 @@ class Timezones:
 			symlink(file, "/etc/localtime")
 		except (IOError, OSError) as err:
 			print "[Timezones] Error %d: Linking '%s' to '/etc/localtime'! (%s)" % (err.errno, file, err.strerror)
+			pass
+		try:
+			with open("/etc/timezone", "w") as fd:
+				fd.write("%s\n" % tz)
+		except (IOError, OSError) as err:
+			print "[Timezones] Error %d: Updating '/etc/timezone'! (%s)" % (err.errno, err.strerror)
 			pass
 		environ["TZ"] = ":%s" % tz
 		try:


### PR DESCRIPTION
[Timezones.py] More code clean up
- Add "/etc/timezone" to the settings updated when the time zone changes. (This is used by Java and some other software.)
- Correct spelling of "timezone" to "time zone" for displayed text.
- Remove superfluous "pass" commands.

[setup.xml] Correct and improve time zone text
- Correct the spelling of "timezone" to "time zone" and make the help text a little more clear.