### PR TITLE
[esubtitle.cpp] Fix some HTML in subtitles

### DIFF
--- a/lib/gui/esubtitle.cpp
+++ b/lib/gui/esubtitle.cpp
@@ -355,8 +355,8 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 				text = replace_all(text, "&apos;", "'");
 				text = replace_all(text, "&quot;", "\"");
 				text = replace_all(text, "&amp;", "&");
-				text = replace_all(text, "&lt", "<");
-				text = replace_all(text, "&gt", ">");
+				text = replace_all(text, "&lt;", "<");
+				text = replace_all(text, "&gt;", ">");
 
 				if (eConfigManager::getConfigBoolValue("config.subtitles.pango_subtitle_fontswitch"))
 				{
@@ -388,6 +388,13 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 					text = replace_all(text, "<u>", "");
 					text = replace_all(text, "<i>", "");
 					text = replace_all(text, "<b>", "");
+				}
+				text = replace_all(text, "</font>", "");
+				unsigned subtitleFont = 0;
+				while ((subtitleFont = text.find("<font ", subtitleFont)) != std::string::npos)
+				{
+					unsigned end = text.find('>', subtitleFont);
+					text.erase(subtitleFont, end - subtitleFont + 1);
 				}
 				subtitleStyles[face].font->pointSize=fontsize;
 				painter.setFont(subtitleStyles[face].font);


### PR DESCRIPTION
- Subtitles containing `&gt;` or `&lt;` were leaving behind the semicolon.
- Remove `<font...>` and `</font>` tags.

This fix by Adoxa taken from the Beyonwiz image.
