### PR TITLE
TemplatedMultiContent clean up

### DIFF
--- a/lib/python/Components/Converter/TemplatedMultiContent.py
+++ b/lib/python/Components/Converter/TemplatedMultiContent.py
@@ -2,23 +2,22 @@ from Components.Converter.StringList import StringList
 
 class TemplatedMultiContent(StringList):
 	"""Turns a python tuple list into a multi-content list which can be used in a listbox renderer."""
+
 	def __init__(self, args):
 		StringList.__init__(self, args)
-		from enigma import eListboxPythonMultiContent, gFont, RT_HALIGN_LEFT, RT_HALIGN_CENTER, RT_HALIGN_RIGHT, RT_VALIGN_TOP, RT_VALIGN_CENTER, RT_VALIGN_BOTTOM, RT_WRAP, BT_SCALE
+		from enigma import BT_SCALE, RT_HALIGN_CENTER, RT_HALIGN_LEFT, RT_HALIGN_RIGHT, RT_VALIGN_BOTTOM, RT_VALIGN_CENTER, RT_VALIGN_TOP, RT_WRAP, eListboxPythonMultiContent, gFont
 		from skin import parseFont
-		from Components.MultiContent import MultiContentEntryText, MultiContentEntryPixmap, MultiContentEntryPixmapAlphaTest, MultiContentEntryPixmapAlphaBlend, MultiContentTemplateColor, MultiContentEntryProgress, MultiContentEntryProgressPixmap 
-		l = locals()
-		del l["self"] # cleanup locals a bit
-		del l["args"]
-
+		from Components.MultiContent import MultiContentEntryPixmap, MultiContentEntryPixmapAlphaBlend, MultiContentEntryPixmapAlphaTest, MultiContentEntryProgress, MultiContentEntryProgressPixmap, MultiContentEntryText, MultiContentTemplateColor
+		loc = locals()
+		del loc["self"]  # Cleanup locals a bit.
+		del loc["args"]
 		self.active_style = None
-		self.template = eval(args, {}, l)
+		self.template = eval(args, {}, loc)
 		assert "fonts" in self.template
 		assert "itemHeight" in self.template
 		assert "template" in self.template or "templates" in self.template
-		assert "template" in self.template or "default" in self.template["templates"] # we need to have a default template
-
-		if not "template" in self.template: # default template can be ["template"] or ["templates"]["default"]
+		assert "template" in self.template or "default" in self.template["templates"]  # We need to have a default template.
+		if "template" not in self.template:  # Default template can be ["template"] or ["templates"]["default"].
 			self.template["template"] = self.template["templates"]["default"][1]
 			self.template["itemHeight"] = self.template["template"][0]
 
@@ -26,44 +25,32 @@ class TemplatedMultiContent(StringList):
 		if not self.content:
 			from enigma import eListboxPythonMultiContent
 			self.content = eListboxPythonMultiContent()
-
-			# also setup fonts (also given by source)
-			index = 0
-			for f in self.template["fonts"]:
-				self.content.setFont(index, f)
-				index += 1
-
-		# if only template changed, don't reload list
-		if what[0] == self.CHANGED_SPECIFIC and what[1] == "style":
+			for index, font in enumerate(self.template["fonts"]):  # Setup fonts (also given by source).
+				self.content.setFont(index, font)
+		if what[0] == self.CHANGED_SPECIFIC and what[1] == "style":  # If only template changed, don't reload list.
 			pass
 		elif self.source:
 			self.content.setList(self.source.list)
-
 		self.setTemplate()
 		self.downstream_elements.changed(what)
 
 	def setTemplate(self):
 		if self.source:
 			style = self.source.style
-
 			if style == self.active_style:
 				return
-
-			# if skin defined "templates", that means that it defines multiple styles in a dict. template should still be a default
-			templates = self.template.get("templates")
+			templates = self.template.get("templates")  # If skin defined "templates", that means that it defines multiple styles in a dict. template should still be a default.
 			template = self.template.get("template")
 			itemheight = self.template["itemHeight"]
 			selectionEnabled = self.template.get("selectionEnabled", True)
 			scrollbarMode = self.template.get("scrollbarMode", "showOnDemand")
-
-			if templates and style and style in templates: # if we have a custom style defined in the source, and different templates in the skin, look it up
+			if templates and style and style in templates:  # If we have a custom style defined in the source, and different templates in the skin, look it up
 				template = templates[style][1]
 				itemheight = templates[style][0]
 				if len(templates[style]) > 2:
 					selectionEnabled = templates[style][2]
 				if len(templates[style]) > 3:
 					scrollbarMode = templates[style][3]
-
 			self.content.setTemplate(template)
 			self.content.setItemHeight(itemheight)
 			self.selectionEnabled = selectionEnabled

--- a/lib/python/Components/MultiContent.py
+++ b/lib/python/Components/MultiContent.py
@@ -9,7 +9,7 @@ def __resolveColor(color):
 		try:
 			return parseColor(color).argb()
 		except Exception as err:
-			print "[MultiContent] Error: Resolve color '%s'" % err
+			print "[MultiContent] Error: Resolve color '%s'" % str(err)
 		return None
 	return color
 
@@ -18,7 +18,7 @@ def __resolvePixmap(pixmap):
 		try:
 			return LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, pixmap))
 		except Exception as err:
-			print "[MultiContent] Error: Resolve pixmap '%s'" % err
+			print "[MultiContent] Error: Resolve pixmap '%s'" % str(err)
 		return None
 	return pixmap
 

--- a/lib/python/Components/MultiContent.py
+++ b/lib/python/Components/MultiContent.py
@@ -1,42 +1,44 @@
-from enigma import eListboxPythonMultiContent, RT_HALIGN_LEFT, RT_VALIGN_TOP
+from enigma import RT_HALIGN_LEFT, RT_VALIGN_TOP, eListboxPythonMultiContent
+
 from skin import parseColor
+from Tools.Directories import SCOPE_CURRENT_SKIN, resolveFilename
 from Tools.LoadPixmap import LoadPixmap
-from Tools.Directories import resolveFilename, SCOPE_ACTIVE_SKIN
 
 def __resolveColor(color):
 	if isinstance(color, str):
 		try:
 			return parseColor(color).argb()
-		except Exception, e:
-			print "[MultiContent]", e
+		except Exception as err:
+			print "[MultiContent] Error: Resolve color '%s'" % err
 		return None
 	return color
 
 def __resolvePixmap(pixmap):
 	if isinstance(pixmap, str):
 		try:
-			return LoadPixmap(resolveFilename(SCOPE_ACTIVE_SKIN, pixmap))
-		except Exception, e:
-			print "[MultiContent]", e
+			return LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, pixmap))
+		except Exception as err:
+			print "[MultiContent] Error: Resolve pixmap '%s'" % err
 		return None
 	return pixmap
 
-def MultiContentTemplateColor(n): return 0xff000000 | n
+def MultiContentTemplateColor(n):
+	return 0xff000000 | n
 
-def MultiContentEntryText(pos = (0, 0), size = (0, 0), font = 0, flags = RT_HALIGN_LEFT | RT_VALIGN_TOP, text = "", color = None, color_sel = None, backcolor = None, backcolor_sel = None, border_width = None, border_color = None):
+def MultiContentEntryText(pos=(0, 0), size=(0, 0), font=0, flags=RT_HALIGN_LEFT | RT_VALIGN_TOP, text="", color=None, color_sel=None, backcolor=None, backcolor_sel=None, border_width=None, border_color=None):
 	return eListboxPythonMultiContent.TYPE_TEXT, pos[0], pos[1], size[0], size[1], font, flags, text, __resolveColor(color), __resolveColor(color_sel), __resolveColor(backcolor), __resolveColor(backcolor_sel), border_width, __resolveColor(border_color)
 
-def MultiContentEntryPixmap(pos = (0, 0), size = (0, 0), png = None, backcolor = None, backcolor_sel = None, flags = 0):
+def MultiContentEntryPixmap(pos=(0, 0), size=(0, 0), png=None, backcolor=None, backcolor_sel=None, flags=0):
 	return eListboxPythonMultiContent.TYPE_PIXMAP, pos[0], pos[1], size[0], size[1], __resolvePixmap(png), __resolveColor(backcolor), __resolveColor(backcolor_sel), flags
 
-def MultiContentEntryPixmapAlphaTest(pos = (0, 0), size = (0, 0), png = None, backcolor = None, backcolor_sel = None, flags = 0):
+def MultiContentEntryPixmapAlphaTest(pos=(0, 0), size=(0, 0), png=None, backcolor=None, backcolor_sel=None, flags=0):
 	return eListboxPythonMultiContent.TYPE_PIXMAP_ALPHATEST, pos[0], pos[1], size[0], size[1], __resolvePixmap(png), __resolveColor(backcolor), __resolveColor(backcolor_sel), flags
 
-def MultiContentEntryPixmapAlphaBlend(pos = (0, 0), size = (0, 0), png = None, backcolor = None, backcolor_sel = None, flags = 0):
+def MultiContentEntryPixmapAlphaBlend(pos=(0, 0), size=(0, 0), png=None, backcolor=None, backcolor_sel=None, flags=0):
 	return eListboxPythonMultiContent.TYPE_PIXMAP_ALPHABLEND, pos[0], pos[1], size[0], size[1], __resolvePixmap(png), __resolveColor(backcolor), __resolveColor(backcolor_sel), flags
 
-def MultiContentEntryProgress(pos = (0, 0), size = (0, 0), percent = None, borderWidth = None, foreColor = None, foreColorSelected = None, backColor = None, backColorSelected = None):
-	return eListboxPythonMultiContent.TYPE_PROGRESS, pos[0], pos[1], size[0], size[1], percent, borderWidth,  __resolveColor(foreColor),  __resolveColor(foreColorSelected),  __resolveColor(backColor),  __resolveColor(backColorSelected)
+def MultiContentEntryProgress(pos=(0, 0), size=(0, 0), percent=None, borderWidth=None, foreColor=None, foreColorSelected=None, backColor=None, backColorSelected=None):
+	return eListboxPythonMultiContent.TYPE_PROGRESS, pos[0], pos[1], size[0], size[1], percent, borderWidth, __resolveColor(foreColor), __resolveColor(foreColorSelected), __resolveColor(backColor), __resolveColor(backColorSelected)
 
-def MultiContentEntryProgressPixmap(pos = (0, 0), size = (0, 0), percent = None, pixmap = None, borderWidth = None, foreColor = None, foreColorSelected = None, backColor = None, backColorSelected = None):
-	return eListboxPythonMultiContent.TYPE_PROGRESS_PIXMAP, pos[0], pos[1], size[0], size[1], percent, __resolvePixmap(pixmap), borderWidth,  __resolveColor(foreColor),  __resolveColor(foreColorSelected),  __resolveColor(backColor),  __resolveColor(backColorSelected)
+def MultiContentEntryProgressPixmap(pos=(0, 0), size=(0, 0), percent=None, pixmap=None, borderWidth=None, foreColor=None, foreColorSelected=None, backColor=None, backColorSelected=None):
+	return eListboxPythonMultiContent.TYPE_PROGRESS_PIXMAP, pos[0], pos[1], size[0], size[1], percent, __resolvePixmap(pixmap), borderWidth, __resolveColor(foreColor), __resolveColor(foreColorSelected), __resolveColor(backColor), __resolveColor(backColorSelected)


### PR DESCRIPTION
- [MultiContent.py] Clean up code
  - PEP8 clean up the code.
  - Synchronise code with other images.

- [TemplatedMultiContent.py] Clean up code …
  - PEP8 clean up the code.
  - Synchronise code with other images.

- [MultiContent.py] Cast error text as a string
  - This was a suggested improvement.
