### PR TITLE
[skin.py] Log font errors

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -770,12 +770,17 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_CURRENT
 			else:
 				render = 0
 			filename = resolveFilename(SCOPE_FONTS, filename, path_prefix=pathSkin)
-			addFont(filename, name, scale, isReplacement, render)
-			# Log provided by C++ addFont code.
-			# print "[Skin] Add font: Font path='%s', name='%s', scale=%d, isReplacement=%s, render=%d." % (filename, name, scale, isReplacement, render)
+			if isfile(filename):
+				addFont(filename, name, scale, isReplacement, render)
+				# Log provided by C++ addFont code.
+				# print "[Skin] Add font: Font path='%s', name='%s', scale=%d, isReplacement=%s, render=%d." % (filename, name, scale, isReplacement, render)
+			else:
+				raise SkinError("Font file '%s' not found" % filename)
 		fallbackFont = resolveFilename(SCOPE_FONTS, "fallback.font", path_prefix=pathSkin)
 		if isfile(fallbackFont):
 			addFont(fallbackFont, "Fallback", 100, -1, 0)
+		# else:  # As this is optional don't raise an error.
+		# 	raise SkinError("Fallback font '%s' not found" % fallbackFont)
 		for alias in tag.findall("alias"):
 			try:
 				name = alias.attrib.get("name")


### PR DESCRIPTION
Log font not found errors at the Python layer rather than relying on the C++ layer.
