### PR TITLE
[eerror.cpp] Consistently display 4 digits

### DIFF
--- a/lib/base/eerror.cpp
+++ b/lib/base/eerror.cpp
@@ -152,7 +152,7 @@ int formatTime(char *buf, int bufferSize, int flags)
 			struct timeval tim;
 			gettimeofday(&tim, NULL);
 			localtime_r(&tim.tv_sec, &loctime);
-			pos += snprintf(buf + pos, bufferSize - pos, "%02d:%02d:%02d.%03lu ", 
+			pos += snprintf(buf + pos, bufferSize - pos, "%02d:%02d:%02d.%04lu ", 
 				loctime.tm_hour, loctime.tm_min, loctime.tm_sec, tim.tv_usec / 100L);
 		}
 	}


### PR DESCRIPTION
The %03lu format is insufficient for 4 digit numbers which will show as 4 digits.  This means that 3 digit numbers trigger an uneven log display.  This change ensures that all numbers display as 4 digits.
