### PR TITLE
[rcinput.cpp] Add decimal display of key code

### DIFF
--- a/lib/driver/rcinput.cpp
+++ b/lib/driver/rcinput.cpp
@@ -20,7 +20,7 @@ void eRCDeviceInputDev::handleCode(long rccode)
 	if (ev->type != EV_KEY)
 		return;
 		
-	eDebug("[eInputDeviceInit] %x %x %x", ev->value, ev->code, ev->type);
+	eDebug("[eInputDeviceInit] %x %x (%u) %x", ev->value, ev->code, ev->code, ev->type);
 
 	int km = iskeyboard ? input->getKeyboardMode() : eRCInput::kmNone;
 


### PR DESCRIPTION
Add a decimal display of the current key code to allow a more direct match to the decimal values displayed within Enigma2.
