### PR TITLE
Centralise the menu path code

### DIFF
--- a/lib/python/Components/GUISkin.py
+++ b/lib/python/Components/GUISkin.py
@@ -3,24 +3,24 @@ from skin import applyAllAttributes
 from Tools.CList import CList
 from Sources.StaticText import StaticText
 
+
 class GUISkin:
 	__module__ = __name__
 
 	def __init__(self):
 		self["Title"] = StaticText()
-		self.onLayoutFinish = [ ]
+		self.onLayoutFinish = []
 		self.summaries = CList()
 		self.instance = None
 		self.desktop = None
 
-	def createGUIScreen(self, parent, desktop, updateonly = False):
+	def createGUIScreen(self, parent, desktop, updateonly=False):
 		for val in self.renderer:
 			if isinstance(val, GUIComponent):
 				if not updateonly:
 					val.GUIcreate(parent)
 				if not val.applySkin(desktop, self):
 					print "[GUISkin] warning, skin is missing renderer", val, "in", self
-
 		for key in self:
 			val = self[key]
 			if isinstance(val, GUIComponent):
@@ -33,15 +33,13 @@ class GUISkin:
 						print "[GUISkin] OBSOLETE COMPONENT WILL BE REMOVED %s, PLEASE UPDATE!" % (depr[1])
 				elif not depr:
 					print "[GUISkin] warning, skin is missing element", key, "in", self
-
 		for w in self.additionalWidgets:
 			if not updateonly:
 				w.instance = w.widget(parent)
 				# w.instance.thisown = 0
 			applyAllAttributes(w.instance, desktop, w.skinAttributes, self.scale)
-
 		for f in self.onLayoutFinish:
-			if type(f) is not type(self.close): # is this the best way to do this?
+			if type(f) is not type(self.close):  # is this the best way to do this?
 				exec f in globals(), locals()
 			else:
 				f()
@@ -81,7 +79,7 @@ class GUISkin:
 
 	def applySkin(self):
 		z = 0
-		baseres = (720, 576) # FIXME: a skin might have set another resolution, which should be the base res
+		baseres = (720, 576)  # FIXME: a skin might have set another resolution, which should be the base res
 		idx = 0
 		skin_title_idx = -1
 		title = self.title
@@ -99,16 +97,12 @@ class GUISkin:
 				baseres = tuple([int(x) for x in value.split(',')])
 			idx += 1
 		self.scale = ((baseres[0], baseres[0]), (baseres[1], baseres[1]))
-
 		if not self.instance:
 			from enigma import eWindow
 			self.instance = eWindow(self.desktop, z)
-
 		if skin_title_idx == -1 and title:
 			self.skinAttributes.append(("title", title))
-
 		# we need to make sure that certain attributes come last
 		self.skinAttributes.sort(key=lambda a: {"position": 1}.get(a[0], 0))
-
 		applyAllAttributes(self.instance, self.desktop, self.skinAttributes, self.scale)
 		self.createGUIScreen(self.instance, self.desktop)

--- a/lib/python/Components/GUISkin.py
+++ b/lib/python/Components/GUISkin.py
@@ -87,7 +87,6 @@ class GUISkin:
 
 	def setTitle(self, title, addToPathList=True):
 		pathText = ""
-		self.skin_title = title
 		if addToPathList and title and config.usage.show_menupath.value != "off":
 			if screenPath.lastSelf != self:
 				screenPath.pathList.append(title)

--- a/lib/python/Components/GUISkin.py
+++ b/lib/python/Components/GUISkin.py
@@ -7,17 +7,10 @@ from Components.Sources.StaticText import StaticText
 from Tools.CList import CList
 
 
-class ScreenPath():
-	def __init__(self):
-		self.pathList = []
-		self.lastSelf = None
-
-
-screenPath = ScreenPath()
-
-
 class GUISkin:
 	__module__ = __name__
+	pathList = []
+	lastSelf = None
 
 	def __init__(self):
 		self["Title"] = StaticText()
@@ -78,27 +71,28 @@ class GUISkin:
 			self.summaries.remove(summary)
 
 	def clearScreenPath(self):
-		screenPath.pathList = []
-		screenPath.lastSelf = None
+		GUISkin.pathList = []
+		GUISkin.lastSelf = None
 
 	def removeScreenPath(self):
-		screenPath.pathList = screenPath.pathList and screenPath.pathList[:-1]
-		screenPath.lastSelf = None
+		if GUISkin.pathList:
+			GUISkin.pathList.pop()
+		GUISkin.lastSelf = None
 
 	def setTitle(self, title, addToPathList=True):
 		pathText = ""
 		if addToPathList and title and config.usage.show_menupath.value != "off":
-			if screenPath.lastSelf != self:
-				screenPath.pathList.append(title)
+			if GUISkin.lastSelf != self:
+				GUISkin.pathList.append(title)
 				self.onClose.append(self.removeScreenPath)
-				screenPath.lastSelf = self
-			elif screenPath.pathList:
-				screenPath.pathList[-1] = title
+				GUISkin.lastSelf = self
+			elif GUISkin.pathList:
+				GUISkin.pathList[-1] = title
 			if config.usage.show_menupath.value == "small":
-				pathText = len(screenPath.pathList) > 1 and " > ".join(screenPath.pathList[:-1]) + " >" or ""
+				pathText = len(GUISkin.pathList) > 1 and " > ".join(GUISkin.pathList[:-1]) + " >" or ""
 			else:
-				title = screenPath.pathList and " > ".join(screenPath.pathList) or title
-			# print "[GUISkin] DEBUG: title='%s', pathList='%s', self='%s'." % (title, str(screenPath.pathList), str(self))
+				title = GUISkin.pathList and " > ".join(GUISkin.pathList) or title
+			# print "[GUISkin] DEBUG: title='%s', pathList='%s', self='%s'." % (title, str(GUISkin.pathList), str(self))
 		if self.instance:
 			self.instance.setTitle(title)
 		self["Title"].text = title

--- a/lib/python/Components/GUISkin.py
+++ b/lib/python/Components/GUISkin.py
@@ -7,11 +7,21 @@ from Components.Sources.StaticText import StaticText
 from Tools.CList import CList
 
 
+class ScreenPath():
+	def __init__(self):
+		self.pathList = []
+		self.lastSelf = None
+
+
+screenPath = ScreenPath()
+
+
 class GUISkin:
 	__module__ = __name__
 
 	def __init__(self):
 		self["Title"] = StaticText()
+		self["ScreenPath"] = StaticText()
 		self.onLayoutFinish = []
 		self.summaries = CList()
 		self.instance = None
@@ -67,10 +77,35 @@ class GUISkin:
 		if summary is not None:
 			self.summaries.remove(summary)
 
-	def setTitle(self, title):
+	def clearScreenPath(self):
+		screenPath.pathList = []
+		screenPath.lastSelf = None
+
+	def removeScreenPath(self):
+		screenPath.pathList = screenPath.pathList and screenPath.pathList[:-1]
+		screenPath.lastSelf = None
+
+	def setTitle(self, title, addToPathList=True):
+		pathText = ""
+		self.skin_title = title
+		if addToPathList and title and config.usage.show_menupath.value != "off":
+			if screenPath.lastSelf != self:
+				screenPath.pathList.append(title)
+				self.onClose.append(self.removeScreenPath)
+				screenPath.lastSelf = self
+			elif screenPath.pathList:
+				screenPath.pathList[-1] = title
+			if config.usage.show_menupath.value == "small":
+				pathText = len(screenPath.pathList) > 1 and " > ".join(screenPath.pathList[:-1]) + " >" or ""
+			else:
+				title = screenPath.pathList and " > ".join(screenPath.pathList) or title
+			# print "[GUISkin] DEBUG: title='%s', pathList='%s', self='%s'." % (title, str(screenPath.pathList), str(self))
 		if self.instance:
 			self.instance.setTitle(title)
 		self["Title"].text = title
+		self["ScreenPath"].text = pathText
+		if "menu_path_compressed" in self:  # Support legacy OpenViX screen history.
+			self["menu_path_compressed"].text = pathText
 		self.summaries.setTitle(title)
 
 	def getTitle(self):

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -517,7 +517,7 @@ class SecondInfoBar(Screen):
 		if description and extended:
 			description += '\n'
 		text = description + extended
-		self.setTitle(event.getEventName())
+		self.setTitle(event.getEventName(), addToPathList=False)
 		self["epg_description"].setText(text)
 		serviceref = self.currentService
 		eventid = self.event.getEventId()
@@ -595,6 +595,7 @@ class InfoBarShowHide(InfoBarScreenSaver):
 		self.onExecBegin.append(self.__onExecBegin)
 
 	def __onExecBegin(self):
+		self.clearScreenPath()
 		self.showHideVBI()
 
 	def __layoutFinished(self):


### PR DESCRIPTION
[GUISkin.py] PEP8 clean up

[GUISkin.py] Tidy up the code
- Sort and move imports to the top of the file.
- Add proposal to address the baseRes FIXME comment.
- camelCase variables.
- Tidy up the comments.
- Tidy up the debug log prints.

[GUISkin.py] Centralise the menu path code
- This change makes the code that calculates and displays the menu path a common piece of code that all Enigma2 code can use without specifically needing to manage the menu path internally to selected modules.

- This change adds a new screen widget called "ScreenPath" that can be used by skinners to share the feature with other images that also have the feature but use different screen widget names.  The code automatically maps the new menu path logic onto the existing "menu_path_compressed" widget.

[InfoBarGenerics.py] Support centralised menu path
- The clearScreenPath() method resets the menu path history when the user returns to the main screen.

- The current event setTitle() is used to send the current show to the front panel but it should not be used in the  menu history.  To stop the event name from being harvested the new "addToPathList=False" argument is used.

[GuiSkin.py] Remove spurious line
- Remove a spurious line that shouldn't be included.  (Possibly a copy / paste error in preparing the pull request.)

[GUISkin.py] Optimise code
- Add code optimisation as suggested by Prl.

NOTE: As requested the Python 3 format print statements have not been provided but can be added if requested.
