### PR TITLE
Centralise the menu path code

### DIFF
--- a/lib/python/Components/GUISkin.py
+++ b/lib/python/Components/GUISkin.py
@@ -3,24 +3,24 @@ from skin import applyAllAttributes
 from Tools.CList import CList
 from Sources.StaticText import StaticText
 
+
 class GUISkin:
 	__module__ = __name__
 
 	def __init__(self):
 		self["Title"] = StaticText()
-		self.onLayoutFinish = [ ]
+		self.onLayoutFinish = []
 		self.summaries = CList()
 		self.instance = None
 		self.desktop = None
 
-	def createGUIScreen(self, parent, desktop, updateonly = False):
+	def createGUIScreen(self, parent, desktop, updateonly=False):
 		for val in self.renderer:
 			if isinstance(val, GUIComponent):
 				if not updateonly:
 					val.GUIcreate(parent)
 				if not val.applySkin(desktop, self):
 					print "[GUISkin] warning, skin is missing renderer", val, "in", self
-
 		for key in self:
 			val = self[key]
 			if isinstance(val, GUIComponent):
@@ -33,15 +33,13 @@ class GUISkin:
 						print "[GUISkin] OBSOLETE COMPONENT WILL BE REMOVED %s, PLEASE UPDATE!" % (depr[1])
 				elif not depr:
 					print "[GUISkin] warning, skin is missing element", key, "in", self
-
 		for w in self.additionalWidgets:
 			if not updateonly:
 				w.instance = w.widget(parent)
 				# w.instance.thisown = 0
 			applyAllAttributes(w.instance, desktop, w.skinAttributes, self.scale)
-
 		for f in self.onLayoutFinish:
-			if type(f) is not type(self.close): # is this the best way to do this?
+			if type(f) is not type(self.close):  # is this the best way to do this?
 				exec f in globals(), locals()
 			else:
 				f()
@@ -81,7 +79,7 @@ class GUISkin:
 
 	def applySkin(self):
 		z = 0
-		baseres = (720, 576) # FIXME: a skin might have set another resolution, which should be the base res
+		baseres = (720, 576)  # FIXME: a skin might have set another resolution, which should be the base res
 		idx = 0
 		skin_title_idx = -1
 		title = self.title
@@ -99,16 +97,12 @@ class GUISkin:
 				baseres = tuple([int(x) for x in value.split(',')])
 			idx += 1
 		self.scale = ((baseres[0], baseres[0]), (baseres[1], baseres[1]))
-
 		if not self.instance:
 			from enigma import eWindow
 			self.instance = eWindow(self.desktop, z)
-
 		if skin_title_idx == -1 and title:
 			self.skinAttributes.append(("title", title))
-
 		# we need to make sure that certain attributes come last
 		self.skinAttributes.sort(key=lambda a: {"position": 1}.get(a[0], 0))
-
 		applyAllAttributes(self.instance, self.desktop, self.skinAttributes, self.scale)
 		self.createGUIScreen(self.instance, self.desktop)

--- a/lib/python/Components/GUISkin.py
+++ b/lib/python/Components/GUISkin.py
@@ -12,6 +12,8 @@ class GUISkin:
 
 	def __init__(self):
 		self["Title"] = StaticText()
+		self["ScreenPath"] = StaticText()
+		self["menu_path_compressed"] = StaticText()  # Support legacy screen history skins.
 		self.onLayoutFinish = []
 		self.summaries = CList()
 		self.instance = None
@@ -67,11 +69,19 @@ class GUISkin:
 		if summary is not None:
 			self.summaries.remove(summary)
 
-	def setTitle(self, title):
+	def setTitle(self, title, showPath=True):
+		pathText = ""
+		if showPath and config.usage.show_menupath.value != "off" and len(self.session.dialog_stack) > 1:
+			if config.usage.show_menupath.value == "small":
+				pathText = "%s >" % " > ".join(ds[0].getTitle() for ds in self.session.dialog_stack[1:])
+			else:
+				title = "%s > %s" % (self.session.dialog_stack[-1][0].getTitle(), title)
 		if self.instance:
 			self.instance.setTitle(title)
-		self["Title"].text = title
 		self.summaries.setTitle(title)
+		self["Title"].text = title
+		self["ScreenPath"].text = pathText
+		self["menu_path_compressed"].text = pathText  # Support legacy screen history skins.
 
 	def getTitle(self):
 		return self["Title"].text

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -80,7 +80,7 @@ class Menu(Screen, ProtectedScreen):
 		self.session.openWithCallback(self.menuClosed, *dialog)
 
 	def openSetup(self, dialog):
-		self.session.openWithCallback(self.menuClosed, Setup, dialog, None, full_menu_path)
+		self.session.openWithCallback(self.menuClosed, Setup, dialog, None)
 
 	def addMenu(self, destList, node):
 		requires = node.get("requires")
@@ -102,10 +102,6 @@ class Menu(Screen, ProtectedScreen):
 		destList.append((MenuTitle, a, entryID, weight))
 
 	def menuClosedWithConfigFlush(self, *res):
-		global menu_path
-		menu_path = ""
-		global full_menu_path
-		full_menu_path = ""
 		configfile.save()
 		self.menuClosed(*res)
 
@@ -269,27 +265,7 @@ class Menu(Screen, ProtectedScreen):
 
 		a = parent.get("title", "").encode("UTF-8") or None
 		a = a and _(a) or _(parent.get("text", "").encode("UTF-8"))
-		self.menu_title = a
-		global menu_path
-		self.menu_path_compressed = menu_path
-		if menu_path == "":
-			menu_path += a
-		elif not menu_path.endswith(a):
-			menu_path += " / " + a
-		global full_menu_path
-		full_menu_path = menu_path + ' / '
-		if config.usage.show_menupath.value == 'large':
-			Screen.setTitle(self, menu_path)
-			self["title"] = StaticText(menu_path)
-			self["menu_path_compressed"] = StaticText("")
-		elif config.usage.show_menupath.value == 'small':
-			Screen.setTitle(self, a)
-			self["title"] = StaticText(a)
-			self["menu_path_compressed"] = StaticText(self.menu_path_compressed and self.menu_path_compressed + " >" or "")
-		else:
-			Screen.setTitle(self, a)
-			self["title"] = StaticText(a)
-			self["menu_path_compressed"] = StaticText("")
+		self.setTitle(a)
 
 		self.number = 0
 		self.nextNumberTimer = eTimer()
@@ -310,18 +286,10 @@ class Menu(Screen, ProtectedScreen):
 		self.number = 0
 
 	def closeNonRecursive(self):
-		global menu_path
-		menu_path = self.menu_path_compressed
-		global full_menu_path
-		full_menu_path = menu_path + ' / '
 		self.resetNumberKey()
 		self.close(False)
 
 	def closeRecursive(self):
-		global menu_path
-		menu_path = ""
-		global full_menu_path
-		full_menu_path = ""
 		self.resetNumberKey()
 		self.close(True)
 

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -43,7 +43,7 @@ class SetupError(Exception):
 class SetupSummary(Screen):
 	def __init__(self, session, parent):
 		Screen.__init__(self, session, parent = parent)
-		self["SetupTitle"] = StaticText(_(parent.setup_title))
+		self["SetupTitle"] = StaticText(parent.setup_title)
 		self["SetupEntry"] = StaticText("")
 		self["SetupValue"] = StaticText("")
 		if hasattr(self.parent,"onChangedEntry"):
@@ -76,12 +76,11 @@ class Setup(ConfigListScreen, Screen):
 
 	ALLOW_SUSPEND = True
 
-	def __init__(self, session, setup, plugin=None, menu_path=None, PluginLanguageDomain=None):
+	def __init__(self, session, setup, plugin=None, PluginLanguageDomain=None):
 		Screen.__init__(self, session)
 		# for the skin: first try a setup_<setupID>, then Setup
 		self.skinName = ["setup_" + setup, "Setup" ]
 
-		self["menu_path_compressed"] = StaticText()
 		self['footnote'] = Label()
 		self["HelpWindow"] = Pixmap()
 		self["HelpWindow"].hide()
@@ -92,7 +91,6 @@ class Setup(ConfigListScreen, Screen):
 		self.force_update_list = False
 		self.plugin = plugin
 		self.PluginLanguageDomain = PluginLanguageDomain
-		self.menu_path = menu_path
 
 		xmldata = setupdom(self.plugin).getroot()
 		for x in xmldata.findall("setup"):
@@ -104,8 +102,9 @@ class Setup(ConfigListScreen, Screen):
 			self.setup_title = x.get("titleshort", "").encode("UTF-8")
 		else:
 			self.setup_title = x.get("title", "").encode("UTF-8")
+		self.setup_title = _("Setup") if self.setup_title == "" else _(self.setup_title)
+		self.setTitle(self.setup_title)
 		self.seperation = int(self.setup.get('separation', '0'))
-
 
 		ConfigListScreen.__init__(self, self.list, session = session, on_change = self.changedEntry)
 		self.createSetupList()
@@ -126,19 +125,6 @@ class Setup(ConfigListScreen, Screen):
 		if not self.handleInputHelpers in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.handleInputHelpers)
 		self.changedEntry()
-		self.onLayoutFinish.append(self.layoutFinished)
-
-	def layoutFinished(self):
-		if config.usage.show_menupath.value == 'large' and self.menu_path:
-			title = self.menu_path + _(self.setup_title)
-			self["menu_path_compressed"].setText("")
-		elif config.usage.show_menupath.value == 'small' and self.menu_path:
-			title = _(self.setup_title)
-			self["menu_path_compressed"].setText(self.menu_path + " >" if not self.menu_path.endswith(' / ') else self.menu_path[:-3] + " >" or "")
-		else:
-			title = _(self.setup_title)
-			self["menu_path_compressed"].setText("")
-		self.setTitle(title)
 
 	def createSetupList(self):
 		currentItem = self["config"].getCurrent()


### PR DESCRIPTION
[GUISkin.py] PEP8 clean up

[GUISkin.py] Tidy up the code
- Sort and move imports to the top of the file.
- Add proposal to address the baseRes FIXME comment.
- camelCase variables.
- Tidy up the comments.
- Tidy up the debug log prints.

[GUISkin.py] Centralise the menu path code
- This change makes the code that calculates and displays the menu path a common piece of code that all Enigma2 code can use without specifically needing to manage the menu path internally to selected modules.
- This change also adds a new optional argument to the setTitle() method that can suppress the path display for the current screen.  This may be useful on screens like MessageBox where a full path display may be undesirable.
- This change adds a new screen widget called "ScreenPath" that can be used by skinners to share the feature with other images that also have the feature but use different screen widget names. The code automatically maps the new menu path logic onto the existing "menu_path_compressed" widget.

[Menu.py] Remove old menu path code
- This change removed the old menu path code as this functionality is now performed by the setTitle() method in GUISkin.py.

[Setup.py] Remove old menu path code
- This change removed the old menu path code as this functionality is now performed by the setTitle() method in GUISkin.py.

Many thanks must go to Prl who contributed many significant improvements to this code.

NOTE: As requested the Python 3 format print statements have not been provided but can be added if requested.
