### PR TITLE
Change global screen variable name

### DIFF
--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -14,7 +14,7 @@ from Components.Sources.Source import Source
 class Screen(dict, GUISkin):
 	NO_SUSPEND, SUSPEND_STOPS, SUSPEND_PAUSES = range(3)
 	ALLOW_SUSPEND = NO_SUSPEND
-	global_screen = None
+	globalScreen = None
 
 	def __init__(self, session, parent=None):
 		dict.__init__(self)
@@ -155,7 +155,7 @@ class Screen(dict, GUISkin):
 		elif name == "parent":
 			return self.parent
 		elif name == "global":
-			return self.global_screen
+			return self.globalScreen
 		return None
 
 	def callLater(self, function):

--- a/mytest.py
+++ b/mytest.py
@@ -174,7 +174,7 @@ from Screens.SessionGlobals import SessionGlobals
 from Screens.Screen import Screen
 
 profile("Screen")
-Screen.global_screen = Globals()
+Screen.globalScreen = Globals()
 
 # Session.open:
 # * push current active dialog ('current_dialog') onto stack


### PR DESCRIPTION
[Screen.py] Use camelCase for global screen variable

[mytest.py] Adjust Screen.py variable reference
- Change the variable name "Screen.global_screen" to "Screen.globalScreen" to match the updated name in Screen.py.
