### PR TITLE
[Menu.py] Restore menu title to display skins

### DIFF
--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -266,6 +266,7 @@ class Menu(Screen, ProtectedScreen):
 		a = parent.get("title", "").encode("UTF-8") or None
 		a = a and _(a) or _(parent.get("text", "").encode("UTF-8"))
 		self.setTitle(a)
+		self["title"] = StaticText(a)  # For compatibility with display skins.
 
 		self.number = 0
 		self.nextNumberTimer = eTimer()


### PR DESCRIPTION
Add a temporary "title" widget to allow some display skins to obtain the current menu title.

All skins should be updated to use the proper "Title" widget rather than "title"!
