### PR TITLE
Refactor Setup

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -71,6 +71,73 @@
 		<key id="KEY_VIDEO" mapto="file" flags="m"/>
 	</map>
 
+	<map context="ConfigListActions">
+		<key id="KEY_RED" mapto="cancel" flags="m" />
+		<key id="KEY_GREEN" mapto="save" flags="m" />
+		<key id="KEY_EXIT" mapto="cancel" flags="b" />
+		<key id="KEY_EXIT" mapto="close" flags="l" />
+		<key id="KEY_MENU" mapto="menu" flags="m" />
+		<key id="KEY_FILE" mapto="menu" flags="m" />
+		<key id="KEY_MEDIA" mapto="menu" flags="m" />
+		<key id="KEY_VIDEO" mapto="menu" flags="m" />
+		<key id="KEY_OK" mapto="select" flags="m" />
+		<key id="KEY_REWIND" mapto="top" flags="m" />
+		<key id="KEY_CHANNELUP" mapto="pageUp" flags="mr" />
+		<key id="KEY_UP" mapto="up" flags="mr" />
+		<key id="KEY_PREVIOUS" mapto="first" flags="m" />
+		<key id="KEY_LEFT" mapto="left" flags="mr" />
+		<key id="KEY_RIGHT" mapto="right" flags="mr" />
+		<key id="KEY_NEXT" mapto="last" flags="m" />
+		<key id="KEY_DOWN" mapto="down" flags="mr" />
+		<key id="KEY_CHANNELDOWN" mapto="pageDown" flags="mr" />
+		<key id="KEY_FASTFORWARD" mapto="bottom" flags="m" />
+		<key id="KEY_LAST" mapto="backspace" flags="mr" />
+		<key id="KEY_STOP" mapto="backspace" flags="mr" />
+		<key id="KEY_PLAYPAUSE" mapto="delete" flags="mr" />
+		<key id="KEY_PLAY" mapto="delete" flags="mr" />
+		<key id="KEY_INFO" mapto="toggleOverwrite" flags="m" />
+		<key id="KEY_0" mapto="0" flags="m" />
+		<key id="KEY_1" mapto="1" flags="m" />
+		<key id="KEY_2" mapto="2" flags="m" />
+		<key id="KEY_3" mapto="3" flags="m" />
+		<key id="KEY_4" mapto="4" flags="m" />
+		<key id="KEY_5" mapto="5" flags="m" />
+		<key id="KEY_6" mapto="6" flags="m" />
+		<key id="KEY_7" mapto="7" flags="m" />
+		<key id="KEY_8" mapto="8" flags="m" />
+		<key id="KEY_9" mapto="9" flags="m" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_F1" mapto="cancel" flags="m" />
+		<key id="KEY_F2" mapto="save" flags="m" />
+		<key id="KEY_ESC" mapto="cancel" flags="b" />
+		<key id="KEY_ESC" mapto="close" flags="l" />
+		<key id="KEY_ENTER" mapto="select" flags="m" />
+		<key id="KEY_TAB" mapto="menu" flags="m" />
+		<key id="KEY_F5" mapto="menu" flags="m" />
+		<key id="KEY_HOME" mapto="top" flags="m" />
+		<key id="KEY_PAGEUP" mapto="pageUp" flags="m" />
+		<key id="KEY_PREVIOUSSONG" mapto="first" flags="m" />
+		<key id="KEY_F9" mapto="first" flags="m" />
+		<key id="KEY_PAGEDOWN" mapto="pageDown" flags="m" />
+		<key id="KEY_END" mapto="bottom" flags="m" />
+		<key id="KEY_NEXTSONG" mapto="last" flags="m" />
+		<key id="KEY_F10" mapto="last" flags="m" />
+		<key id="KEY_BACKSPACE" mapto="backspace" flags="mr" />
+		<key id="KEY_DELETE" mapto="delete" flags="mr" />
+		<key id="KEY_INSERT" mapto="toggleInsert" flags="m" />
+		<key id="KEY_ASCII" mapto="gotAsciiCode" flags="mr" />
+		<key id="KEY_KP0" mapto="0" flags="m" />
+		<key id="KEY_KP1" mapto="1" flags="m" />
+		<key id="KEY_KP2" mapto="2" flags="m" />
+		<key id="KEY_KP3" mapto="3" flags="m" />
+		<key id="KEY_KP4" mapto="4" flags="m" />
+		<key id="KEY_KP5" mapto="5" flags="m" />
+		<key id="KEY_KP6" mapto="6" flags="m" />
+		<key id="KEY_KP7" mapto="7" flags="m" />
+		<key id="KEY_KP8" mapto="8" flags="m" />
+		<key id="KEY_KP9" mapto="9" flags="m" />
+	</map>
+
 	<map context="VirtualKeyBoardActions">
 		<key id="KEY_RED" mapto="cancel" flags="m" />
 		<key id="KEY_GREEN" mapto="save" flags="m" />

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -1,5 +1,5 @@
 <!--suppress XmlUnboundNsPrefix -->
-<!-- "titleshort" attribute is optional. If present it will be used as the item title in the menu. It will also be used as the header in setup screens when menu path is enabled. -->
+<!-- "menuTitle" attribute is optional. If present it will be used as the item title in the menu. It will also be used as the header in setup screens when menu path is enabled. -->
 <setupxml>
 	<setup key="time" title="Time">
 		<item level="0" text="Time zone area" description="Select your time zone area or region.">config.timezone.area</item>
@@ -10,10 +10,10 @@
 		<item level="0" text="Date style" description="Choose the display formatting style for dates. 'D' / 'DD' is the date and 'M' / 'MM' is the month in digits.  ('DD' and 'MM' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin." requires="config.usage.date.enabled">config.usage.date.dayfull</item>
 		<item level="0" text="Time style" description="Choose the display formatting style for times. 'H' / 'HH' is the hour for a 24 hour clock, 'h' / 'hh' is the hour for a 12 hour clock, 'mm' is the minutes and 'ss' is the seconds.  ('HH' and 'hh' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin." requires="config.usage.time.enabled">config.usage.time.long</item>
 	</setup>
-	<setup key="avsetup">
+	<setup key="avsetup" title="A/V settings">
 		<!-- This is just a placeholder, the Videomode plugin implements this submenu -->
 	</setup>
-	<setup key="usage" title="Customize settings" titleshort="Customize">
+	<setup key="usage" title="Customize settings" menuTitle="Customize">
 		<item level="0" text="Setup mode" description="Choose which level of menu/settings to display. 'Expert' level shows all items.">config.usage.setup_level</item>
 		<item level="0" text="Task warning on shutdown" description="On shutdown/restart warn about any pending jobs being carried out in the background.">config.usage.task_warning</item>
 		<item level="1" text="Enable teletext caching" description="When enabled, teletext pages will be cached, allowing faster access.">config.usage.enable_tt_caching</item>
@@ -23,7 +23,7 @@
 		<item level="2" text="Require authentication for http streams" description="When enabled, authentication is required to watch http streams.">config.streaming.authentication</item>
 		<item level="2" text="Wake On LAN" description="When enabled the set top box is able to wakeup on LAN" requires="WakeOnLAN">config.usage.wakeOnLAN</item>
 	</setup>
-	<setup key="tunermisc" title="Tuner miscellaneous" titleshort="Miscellaneous" showOpenWebIF="1">
+	<setup key="tunermisc" title="Tuner miscellaneous" menuTitle="Miscellaneous" showOpenWebIF="1">
 		<item level="1" text="12V output" description="12V output." requires="12V_Output">config.usage.output_12V</item>
 		<item level="2" text="Preferred tuner" description="Configure which tuner will be preferred, when more than one tuner is available. If set to 'auto' the system will give priority to the tuner having the lowest number of channels/satellites.">config.usage.frontend_priority</item>
 		<item level="2" text="Preferred tuner DVB-S" description="When enabled, this setting has more weight than 'Preferred tuner'." requires="DVB-S_priority_tuner_available">config.usage.frontend_priority_dvbs</item>
@@ -41,7 +41,7 @@
 		<item level="2" text="Ignore DVB-T namespace sub network" description="On valid ONIDs, ignore frequency sub network part">config.usage.subnetwork_terrestrial</item>
 		<item level="2" text="Alternative services tuner priority" description="Configure which tuner type will be preferred, when the same service is available on different types of tuners.">config.usage.alternatives_priority</item>
 	</setup>
-	<setup key="userinterface" title="GUI settings" titleshort="Settings">
+	<setup key="userinterface" title="GUI settings" menuTitle="Settings">
 		<item level="0" text="1st Infobar timeout" description="Set the time delay before hiding the infobar.">config.usage.infobar_timeout</item>
 		<item level="2" text="Show second infobar" description="Configure whether (and for how long) a second infobar will be shown when OK is pressed twice. The second infobar contains additional information about the current channel.">config.usage.show_second_infobar</item>
 		<item level="0" text="Enable infobar fade-out" description="Fade the infobar when hiding">config.usage.show_infobar_do_dimming</item>
@@ -112,7 +112,7 @@
 		<item level="1" text="Zap mode" requires="ZapMode" description="Setup how to control the channel changing.">config.misc.zapmode</item>
 		<item level="2" text="Number of digits in channel number" description="This allows you to set the number of digits you can input when selecting channels using number input.">config.usage.maxchannelnumlen</item>
 	</setup>
-	<setup key="epgsettings" title="EPG settings" titleshort="Settings">
+	<setup key="epgsettings" title="EPG settings" menuTitle="Settings">
 		<item level="2" text="EPG location" description="Choose the location where the EPG data will be stored when the %s %s is shut down. The location must be available at boot time.">config.misc.epgcachepath</item>
 		<item level="2" text="EPG filename" description="Choose the name of the file that holds the EPG data when the %s %s is shut down. This can be handy to differentiate between several boxes.">config.misc.epgcachefilename</item>
 		<item level="2" text="Automatic refresh" description="Allows the %s %s to read the stored EPG data regularly.">config.epg.cacheloadsched</item>
@@ -205,10 +205,10 @@
 		<item level="2" text="Offline decode delay (ms)" description="Configure the offline decoding delay (in milliseconds). The configured delay is observed at each control word parity change.">config.recording.offline_decode_delay</item>
 		<item level="2" text="Default recording type" description="Descramble &amp; record ECM' gives the option to descramble afterwards if descrambling on recording failed. 'Don't descramble, record ECM' save a scramble recording that can be descrambled on playback. 'Normal' means descramble the recording and don't record ECM.">config.recording.ecm_data</item>
 	</setup>
-	<setup key="harddisk" title="HDD settings" titleshort="Settings">
+	<setup key="harddisk" title="HDD settings" menuTitle="Settings">
 		<item level="0" text="Hard disk standby after" description="Configure duration of inactivity before the hard disk drive goes to standby">config.usage.hdd_standby</item>
 	</setup>
-	<setup key="network" title="Network settings" titleshort="Settings">
+	<setup key="network" title="Network settings" menuTitle="Settings">
 		<item text="Use DHCP" description="When enabled, use DHCP for the IP configuration.">config.network.dhcp</item>
 		<item text="IP address" description="Configure the IP address.">config.network.ip</item>
 		<item text="Netmask" description="Configure the netmask.">config.network.netmask</item>
@@ -216,7 +216,7 @@
 		<item text="Nameserver" description="Configure the nameserver (DNS).">config.network.dns</item>
 		<item text="Activate network settings" description="Activate the configured network settings.">config.network.activate</item>
 	</setup>
-	<setup key="RFmod" title="RF output settings" titleshort="Settings">
+	<setup key="RFmod" title="RF output settings" menuTitle="Settings">
 		<item level="1" text="Modulator">config.rfmod.enable</item>
 		<item level="2" text="Test mode">config.rfmod.test</item>
 		<item level="2" text="Sound">config.rfmod.sound</item>
@@ -224,10 +224,10 @@
 		<item level="1" text="Channel">config.rfmod.channel</item>
 		<item level="1" text="Finetune">config.rfmod.finetune</item>
 	</setup>
-	<setup key="keyboard" title="Keyboard settings" titleshort="Settings">
+	<setup key="keyboard" title="Keyboard settings" menuTitle="Settings">
 		<item level="0" text="Keyboard map">config.keyboard.keymap</item>
 	</setup>
-	<setup key="display" title="Front panel settings" titleshort="Settings" requires="FrontpanelDisplay">
+	<setup key="display" title="Front panel settings" menuTitle="Settings" requires="FrontpanelDisplay">
 		<item level="0" text="Use separate Picon pack for Front Display" description="Use piconlcd directory for picons on color LCD">config.lcd.picon_pack</item>
 		<item level="0" text="Show MiniTV in the Front Display" description="You can Display MiniTV with or without OSD Menu" requires="LCDMiniTV">config.lcd.minitvmode</item>
 		<item level="0" text="Show PIP in the Front Display" description="You can Display PIP with or without OSD Menu" requires="LCDMiniTVPiP">config.lcd.minitvpipmode</item>
@@ -278,18 +278,18 @@
 		<item text="Latitude" description="Configure the latitude of your location.">config.sat.diseqcb</item>
 		<item text="Use power measurement" description="When enabled, measure power consumption to detect when the rotor stops turning (when supported by the tuner)." >config.sat.diseqcc</item>
 	</setup>
-	<setup key="softwareupdate" title="Software update settings" titleshort="Settings">
+	<setup key="softwareupdate" title="Software update settings" menuTitle="Settings">
 		<item level="1" text="Background check" description="Perform an online update check in the background">config.softwareupdate.check</item>
 		<item level="1" text="Check every (hours)" description="Setup the interval (in hours) to check for online updates." requires="config.softwareupdate.check">config.softwareupdate.checktimer</item>
 		<item level="1" text="Allow unstable (experimental) updates" description="When enabled the online checker will also check for experimental versions">config.softwareupdate.updatebeta</item>
 		<item level="1" text="Automatic settings backup" description="Perform a settings backup before updating.">config.softwareupdate.autosettingsbackup</item>
 		<item level="1" text="Automatic image backup" description="Perform a complete image backup before updating.">config.softwareupdate.autoimagebackup</item>
 	</setup>
-	<setup key="softcamsetup" title="Softcam settings" titleshort="Settings">
+	<setup key="softcamsetup" title="Softcam settings" menuTitle="Settings">
 		<item level="2" text="Show CCcam Info in extensions?" description="Allows you to show/hide CCcam Info in extensions (blue button).">config.cccaminfo.showInExtensions</item>
 		<item level="2" text="Show OScam Info in extensions?" description="Allows you to show/hide OScam Info in extensions (blue button).">config.oscaminfo.showInExtensions</item>
 	</setup>
-	<setup key="logs" title="Logs settings" titleshort="Settings">
+	<setup key="logs" title="Logs settings" menuTitle="Settings">
 		<item level="2" text="Logs folder location" description="Choose the location for crash and debug logs folder.">config.crash.debug_path</item>
 		<item level="2" text="Enable debug logs *" description="Allows you to enable the debug logs. They contain very detailed information about everything the system does. Reboot required to enable this!">config.crash.enabledebug</item>
 		<item level="2" text="Limit debug log size (MB)" description="Allows you to set the maximum size (MB) of the individual debug logs. When that size is reached, the log file will be truncated to the maximum size every 60 minutes.">config.crash.debugloglimit</item>
@@ -397,7 +397,7 @@
 		<item level="2" text="Timeline 24 Hour" description="Show time in 24 hour clock format." requires="config.usage.time.disabled">config.epgselection.grid.timeline24h</item>
 		<item level="2" text="Time scale" description="Configure the amount of time that will be presented.">config.epgselection.grid.prevtimeperiod</item>
 	</setup>
-	<setup key="pluginbrowsersetup" title="Plugin browser settings" titleshort="Settings">
+	<setup key="pluginbrowsersetup" title="Plugin browser settings" menuTitle="Settings">
 		<item level="2" text="Show translation packages" description="If set to 'yes' it will show the 'PO' packages in browser.">config.pluginbrowser.po</item>
 		<item level="2" text="Show source packages" description="If set to 'yes' it will show the 'SRC' packages in browser.">config.pluginbrowser.src</item>
 	</setup>

--- a/doc/SETUP
+++ b/doc/SETUP
@@ -1,0 +1,370 @@
+Standardised and Uniform Setup Menus in Enigma2
+-----------------------------------------------
+
+Written by IanSav -  2-Apr-2018
+Updated by IanSav - 11-Jul-2020
+
+INTRODUCTION:
+=============
+
+Enigma2 is a massive open source project that has many contributors and 
+add-ons.  Over time a number of alternative approaches to performing common 
+tasks have evolved.  This document documents some conventions that can be 
+adopted by all developers, contributors and skin authors to ensure that 
+everyone can work independently but still achieve results that work together 
+interchangeably.
+
+Standard variable names are documented, together with code and skin coding 
+conventions to assist in creating code that works more universally, with 
+additional benefits from improved Setup menu load performance and reduction 
+in merge issues between images.
+
+Lastly, the document explains the operation and features of the refactored 
+Setup menu interface ("Screen/Setup.py").
+
+REFACTOR OF "Screens/Setup.py":
+===============================
+
+The refactor of the "Screens/Setup.py" code has been based on various 
+features available in the main Enigma2 images.  That is, the code has been 
+written to make the "Screens/Setup.py" a superset of capabilities from all 
+the images.
+
+The changes, even with the enhancements, can result in a significant 
+reduction in time to generate any "Screens/Setup.py" based Setup menu.  
+The time taken to build any Setup menu lists is slightly longer for the 
+first menu item but then about 50 time faster for all subsequent searches.
+
+Significant changes, in no particular order, are:
+
+1)	All setup XML file data is cached into memory on the first access.  
+	Every subsequent access will check if the source file has been 
+	changed.  If so, the file will be reloaded and reprocessed.  If not, 
+	the cached results are returned.  This change can significantly 
+	improve "Screens/Setup.py" menu load times.
+
+	This change also means that the GUI no longer has to be restarted to 
+	allow changes to "setup.xml" to be processed by OpenPLi.
+
+2)	All setup menu titles are also extracted and cached to improve menu 
+	building time.  This code uses a derivative of the OpenViX 
+	"titleshort" attribute here known as "menuTitle" to allow 
+	"Screens/Menu.py" based menus to have alternate title text.  This 
+	change improves "Screens/Menu.py" menu load times for "Setup" based 
+	menus.
+
+3)	Optimise, improve and enhance generation of Setup menu item lists.  
+	Thange allows the list to be processed 	once for display rather than 
+	the two or three cycles in some previous versions.
+
+4)	Create a log entry if the Setup menu has no valid entries.
+
+5)	Remove remnants of the setup.xml "separation" attribute directive.  
+	This feature is now offered via the skin parameter 
+	"ConfigListSeperator".
+
+6)	When enabled, always obey Setup menu sort setting.
+
+7)	If "%s %s" is found in an item's "text" or "description" attribute 
+	then replace it with the current box machine brand and model name.
+
+8)	Move the description code from the "SetupSummary" class into the main 
+	"Setup" class where it is used.
+
+9) 	For OpenPLi add footnote support.  If the last character of a menu 
+	item is an "*" then when this item is currently selected by the user 
+	a footnote message will appear to advise the user that a restart 
+	will be required if this item is changed.
+
+10)	Add an option to provide "Setup" menu images based on matching the 
+	setup menu "key" attribute with an image defined in a new "<setups>" 
+	block in the skin.  This code is conditional on having compatible 
+	changes in "skin.py".
+
+11)	Enable the HELP button to allow users to obtain help while using any 
+	"Screens/Setup.py" based screen.  To be fully operational these 
+	changes also need to be accompanied by changes to 
+	"Components/ConfigList.py".
+
+	To properly implement HELP and clean up the ActionMaps, the ActionMap 
+	and associated code should be removed from "Screens/Setup.py" and 
+	integrated into the ActionMap in "Components/ConfigList.py".
+
+12)	The "setup_key" skin facility appears to be unused.  The name has 
+	been changed to "Setup_key" to better match existing skin names.  
+	This option allows skin designers to create custom "Setup" based 
+	screens for any "Setup" menu item.
+
+	The "setup.xml" file's "setup" tag also offers a "skin" attribute to 
+	also allow for the screen for that menu to be specified.
+
+	The order of screen selection is first look for a "skin" attribute 
+	screen, then try for a "Setup_key" screen and finally use the 
+	standard "Setup" screen.
+
+13)	Perform a PEP8 clean-up of the code.
+
+14)	Reorganise the imports and code blocks to improve readability of the 
+	refactored code.
+
+STRUCTURE OF "setup.xml" FILES:
+===============================
+
+Syntax:
+	
+	<setupxml>
+		<setup key="Sample1" title="Sample1 settings">
+			<item level="0" text="Configuration item 1" description="This is the description text that explains the purpose and settings of config item 1.">configItem1</item>
+			<item level="0" text="Configuration item 2" description="This is the description text that explains the purpose and settings of config item 2.">configItem2</item>
+		</setup>
+		<setup key="Sample2" title="Sample2 settings">
+			<item level="0" text="Configuration item 3" description="This is the description text that explains the purpose and settings of config item 3.">configItem3</item>
+			<item level="1" text="Configuration item 4" description="This is the description text that explains the purpose and settings of config item 4.">configItem4</item>
+		</setup>
+	</setupxml>
+
+The "setupxml" tag defines that the file is a setup configuration file. The 
+"setupxml" tag has no attributes and should contain a list of one or more 
+"setup" tag blocks. Each of the "setup" tag blocks should contain a list of 
+one or more "item" blocks.  Each of the "item" tag blocks must contain a 
+configuration element that has been defined in "Components/UsageConfig.py" 
+or elsewhere.
+
+Each of the "setup" tags can have the following attributes:
+
+	Attribute	Required	Description
+	---------	--------	-----------
+	"key"		Mandatory	This attribute is the reference name, 
+					or key, used to identify this Setup 
+					menu.
+
+	"title"		Mandatory	This attribute is the long form title 
+					text used for the heading or title of 
+					this setup menu screen.
+
+	"menuTitle"	Optional	This attribute is the title that can 
+					be used as an alternative for the 
+					"title" in menus of Setup menu items.
+
+	"showOpenWebIF"	Optional	This attribute is used to signal that 
+					this Setup screen should be made 
+					available in OpenWebif.
+
+	"requires"	Optional	This attribute is used to test is the 
+					nominated requirements have been met 
+					to enable the activation and use of 
+					this Setup menu.
+
+	"skin"		Optional	This attribute is used to specify an 
+					override screen name defined in the 
+					skin to be used to display this Setup 
+					screen.
+
+Each of the "item" tags can have the following attributes:
+
+	Attribute	Required	Description
+	---------	--------	-----------
+	"text"		Mandatory	This attribute is the prompt text 
+					that is displayed to the user when 
+					activating this Setup menu.
+
+	"level"		Recommended	The list of items that may be 
+					displayed in any Setup menu is 
+					dynamic. This attribute determines 
+					the user interface setup mode or 
+					level where this option may be 
+					displayed.  The default level, if 
+					not specified, is 0.
+
+				Level=0 -> Basic / Normal / Simple or higher
+				Level=1 -> Advanced / Intermediate or higher
+				Level=2 -> Expert
+				Level=9 -> Deactivate this entry
+
+	"description"	Recommended	This attribute is the help prompt or 
+					information that can, and should, be 
+					used to offer guidance to users in 
+					when and how to set the associated 
+					configuration option.  If this is 
+					omitted no assistance or information 
+					will be offered to users.
+
+	"conditional"	Optional	This attribute allows for programmed 
+					logic to decide is this item is 
+					eligible for display in the Setup 
+					menu.
+
+	"requires"	Optional	This attribute allows for "SystemInfo" 
+					or "config" variables to be used to 
+					enable display of the item.  If the 
+					first character of the attribute 
+					argument is "!" then the argument 
+					logic is inverted.
+
+	NOTE 1:	The text in the "text" and "description" attributes will 
+		be processed by the language translation system.
+
+	NOTE 2:	After the text in the "text" and "description" attributes 
+		has been translated any occurrence of the string "%s %s" will 
+		be replaced by the current make and model of the device upon 
+		which the code is running.
+
+	NOTE 3: If the last character of the "text" attribute is "*" then 
+		when this item is currently selected by the user a footnote 
+		message will appear to advise the user that a restart will be 
+		required if this item is changed.
+
+The payload or data element of the "item" tag should be the config element 
+defined in "Components/UsageConfig.py", or elsewhere, to be managed / changed 
+by the encompassing item tag.
+
+
+"Screens/Setup.py" / "Setup" SCREEN VARIABLES:
+==============================================
+
+	Variable		Description
+	--------		-----------
+	ScreenPath		This variable uses a source="ScreenPath" 
+				render=Label" widget that provides the menu 
+				path to the currently used "Setup" menu.
+
+	Title			This variable uses a source="title" 
+				render=Label" widget that provides the title 
+				of the "Setup" menu.
+
+	config			This variable uses a name="config" widget 
+				that provides the list of available "Setup" 
+				configuration items.
+
+	description		This variable uses a name="description" 
+				widget that provides any available help or 
+				description text for the currently selected 
+				"Setup" item.
+
+	footnote		This variable uses a name="footnote" widget 
+				that provides a footnote message that 
+				typically advises when changing the item's 
+				value may trigger a restart.
+
+	key_red			This variable uses a source="key_red" 
+				render="Label" widget that provides the text 
+				for the RED button.  This variable can also 
+				be used to trigger an associated button 
+				graphic.
+
+	key_green		This variable uses a source="key_green" 
+				render="Label" widget that provides the text 
+				for the GREEN button.  This variable can also 
+				be used to trigger an associated button 
+				graphic.
+
+	key_yellow		This variable uses a source="key_yellow" 
+				render="Label" widget that provides the text 
+				for the YELLOW button.  This variable can 
+				also be used to trigger an associated button 
+				graphic.  The YELLOW button is not used by 
+				the core "Setup" class but may be used by 
+				other code based on the "Setup" class.
+
+	key_blue		This variable uses a source="key_blue" 
+				render="Label" widget that provides the text 
+				for the BLUE button.  This variable can also 
+				be used to trigger an associated button 
+				graphic.  The BLUE button is not used by 
+				the core "Setup" class but may be used by 
+				other code based on the "Setup" class.
+
+	key_menu		This variable uses a source="key_menu" 
+				render="Label" widget that provides a signal 
+				to the skin to display the MENU button.
+
+	key_help		This variable uses a source="key_help" 
+				render="Label" widget that provides a signal 
+				to the skin to display the HELP button.
+
+	VKeyIcon		This variable uses a source="VKeyIcon" 
+				render="Pixmap" widget that provides a signal 
+				to the skin to display the TEXT button when 
+				appropriate.
+
+	HelpWindow		This variable uses a name="HelpWindow" widget 
+				that displays the SMS helper window overlay 
+				when appropriate.
+
+SAMPLE "Setup" SCREEN:
+======================
+
+	<screen name="Setup" title="Setup" position="center,center" size="1000,565">
+		<widget source="ScreenPath" render="Label" position="560,0" size="440,15" conditional="ScreenPath" font="Regular;12" halign="right" transparent="1" />
+		<widget source="Title" render="Label" position="560,15" size="440,25" font="Regular;20" halign="right" noWrap="1" transparent="1" />
+		<widget source="key_red" render="Pixmap" pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="blend" conditional="key_red">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_red" render="Label" position="0,0" size="140,40" backgroundColor="#9f1313" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_green" render="Pixmap" pixmap="buttons/green.png" position="140,0" size="140,40" alphatest="blend" conditional="key_green">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_green" render="Label" position="140,0" size="140,40" backgroundColor="#1f771f" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_yellow" render="Pixmap" pixmap="buttons/yellow.png" position="280,0" size="140,40" alphatest="blend" conditional="key_yellow">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_yellow" render="Label" position="280,0" size="140,40" backgroundColor="#a08500" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_blue" render="Pixmap" pixmap="buttons/blue.png" position="420,0" size="140,40" alphatest="blend" conditional="key_blue">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_blue" render="Label" position="420,0" size="140,40" backgroundColor="#141484" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_menu" render="Pixmap" pixmap="buttons/key_menu.png" position="0,540" size="35,25" alphatest="blend" conditional="key_menu">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_help" render="Pixmap" pixmap="buttons/key_help.png" position="40,540" size="35,25" alphatest="blend" conditional="key_help">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="VKeyIcon" render="Pixmap" pixmap="buttons/key_text.png" position="80,540" size="35,25" alphatest="blend" transparent="1">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget name="HelpWindow" pixmap="buttons/vkey_icon.png" position="0,250" size="1,1" zPosition="+1" />
+		<widget name="menuimage" position="0,50" size="200,400" alphatest="blend" conditional="menuimage" transparent="1" />
+		<widget name="config" position="200,50" size="800,400" enableWrapAround="1" scrollbarMode="showOnDemand" transparent="1" />
+		<widget name="footnote" position="200,460" size="800,20" font="Regular;18" transparent="1" valign="center" />
+		<widget name="description" position="200,490" size="800,75" font="Regular;20" transparent="1" valign="center" />
+	</screen>
+
+SKIN "Setups" SUPPORT BLOCK:
+============================
+
+Syntax:
+
+	<setups>
+		<setup key="default" image="setup_default.png" />
+		<setup key="Sample1" image="setup_key.png" />
+	</setups>
+
+This block is optional but if defined allows a skin designer to associate 
+an image with any "Screens/Setup.py" based menu.  The "setups" tag has no 
+attributes and contains a list of "setup" tags.
+
+Each "setup" tag must contain two attributes:
+
+	key	This attribute is the value of the key attribute from a 
+		setup.xml file.  If the keys match then this entry defines 
+		an image that is to be used when the nominated Setup menu 
+		is displayed.
+
+	image	This attribute is the pathname of the image that is to be 
+		associated with the Setup menu identified by the "key" 
+		attribute.
+
+There is a special "key" attribute with the name "default".  This entry, 
+if defined, assigns a default image to be used in ALL "Screens/Setup.py" 
+screens that do not have a specifically assigned image.
+
+CONCLUSION:
+===========
+
+For all the Enigma2 images there is a significant difference in facilities 
+offered by the "Screens/Setup.py code.  This proposal outlines what I 
+believe to be a conservative approach to making a significant and beneficial 
+change in unifying and standardising the operation of "Setup" menus and 
+screens across the Enigma2 UI.
+
+---END---

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -1,19 +1,24 @@
-from GUIComponent import GUIComponent
-from config import KEY_LEFT, KEY_RIGHT, KEY_HOME, KEY_END, KEY_0, KEY_DELETE, KEY_BACKSPACE, KEY_OK, KEY_TOGGLEOW, KEY_ASCII, KEY_TIMEOUT, KEY_NUMBERS, configfile, ConfigElement
-from Components.ActionMap import NumberActionMap, ActionMap
-from enigma import eListbox, eListboxPythonConfigContent, eRCInput, eTimer
-from Screens.MessageBox import MessageBox
+from enigma import eListbox, eListboxPythonConfigContent, ePoint, eRCInput, eTimer
+from skin import parameters
+
+from Components.ActionMap import HelpableActionMap, HelpableNumberActionMap
+from Components.config import KEYA_LEFT, KEYA_RIGHT, KEYA_HOME, KEYA_END, KEYA_0, KEYA_DELETE, KEYA_BACKSPACE, KEYA_SELECT, KEYA_TOGGLEOW, KEYA_ASCII, KEYA_NUMBERS, KEYA_TIMEOUT, config, configfile, ConfigElement, ConfigText, ConfigBoolean, ConfigSelection
+from Components.GUIComponent import GUIComponent
+from Components.Pixmap import Pixmap
+from Components.Sources.Boolean import Boolean
+from Components.Sources.StaticText import StaticText
 from Screens.ChoiceBox import ChoiceBox
-import skin
+from Screens.MessageBox import MessageBox
+from Screens.VirtualKeyBoard import VirtualKeyBoard
 
 
 class ConfigList(GUIComponent, object):
 	def __init__(self, list, session=None):
 		GUIComponent.__init__(self)
 		self.l = eListboxPythonConfigContent()
-		seperation = skin.parameters.get("ConfigListSeperator", 200)
+		seperation = parameters.get("ConfigListSeperator", 200)
 		self.l.setSeperation(seperation)
-		height, space = skin.parameters.get("ConfigListSlider", (17, 0))
+		height, space = parameters.get("ConfigListSlider", (17, 0))
 		self.l.setSlider(height, space)
 		self.timer = eTimer()
 		self.list = list
@@ -29,20 +34,24 @@ class ConfigList(GUIComponent, object):
 	def execEnd(self):
 		rcinput = eRCInput.getInstance()
 		rcinput.setKeyboardMode(rcinput.kmNone)
+		self.timer.stop()
 		self.timer.callback.remove(self.timeout)
 
-	def toggle(self):
-		selection = self.getCurrent()
-		selection[1].toggle()
-		self.invalidateCurrent()
+	def timeout(self):
+		self.handleKey(KEYA_TIMEOUT)
 
 	def handleKey(self, key):
 		selection = self.getCurrent()
 		if selection and selection[1].enabled:
 			selection[1].handleKey(key)
 			self.invalidateCurrent()
-			if key in KEY_NUMBERS:
+			if key in KEYA_NUMBERS:
 				self.timer.start(1000, 1)
+
+	def toggle(self):
+		selection = self.getCurrent()
+		selection[1].toggle()
+		self.invalidateCurrent()
 
 	def getCurrent(self):
 		return self.l.getCurrentSelection()
@@ -65,6 +74,16 @@ class ConfigList(GUIComponent, object):
 
 	GUI_WIDGET = eListbox
 
+	def isChanged(self):
+		for x in self.list:
+			if x[1].isChanged():
+				return True
+		return False
+
+	def selectionEnabled(self, enabled):
+		if self.instance is not None:
+			self.instance.setSelectionEnable(enabled)
+
 	def selectionChanged(self):
 		if isinstance(self.current, tuple) and len(self.current) >= 2:
 			self.current[1].onDeselect(self.session)
@@ -75,14 +94,6 @@ class ConfigList(GUIComponent, object):
 			return
 		for x in self.onSelectionChanged:
 			x()
-
-	def hideHelp(self):
-		if isinstance(self.current, tuple) and len(self.current) >= 2:
-			self.current[1].hideHelp(self.session)
-
-	def showHelp(self):
-		if isinstance(self.current, tuple) and len(self.current) >= 2:
-			self.current[1].showHelp(self.session)
 
 	def postWidgetCreate(self, instance):
 		instance.selectionChanged.get().append(self.selectionChanged)
@@ -96,26 +107,25 @@ class ConfigList(GUIComponent, object):
 		instance.setContent(None)
 
 	def setList(self, l):
-		self.timer.stop()
+		# self.timer.stop()
 		self.__list = l
 		self.l.setList(self.__list)
 		if l is not None:
 			for x in l:
-				assert len(x) < 2 or isinstance(x[1], ConfigElement), "entry in ConfigList " + str(x[1]) + " must be a ConfigElement"
+				assert len(x) < 2 or isinstance(x[1], ConfigElement), "[ConfigList] Error: Entry in ConfigList '%s' must be a ConfigElement!" % str(x[1])
 
 	def getList(self):
 		return self.__list
 
 	list = property(getList, setList)
 
-	def timeout(self):
-		self.handleKey(KEY_TIMEOUT)
+	def moveTop(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveTop)
 
-	def isChanged(self):
-		for x in self.list:
-			if x[1].isChanged():
-				return True
-		return False
+	def moveBottom(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveEnd)
 
 	def pageUp(self):
 		if self.instance is not None:
@@ -125,53 +135,86 @@ class ConfigList(GUIComponent, object):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.pageDown)
 
+	def moveUp(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveUp)
+
+	def moveDown(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveDown)
+
 
 class ConfigListScreen:
 	def __init__(self, list, session=None, on_change=None):
-		self["config_actions"] = NumberActionMap(["SetupActions", "InputAsciiActions", "KeyboardInputActions"], {
-			"gotAsciiCode": self.keyGotAscii,
-			"ok": self.keyOK,
-			"left": self.keyLeft,
-			"right": self.keyRight,
-			"home": self.keyHome,
-			"end": self.keyEnd,
-			"deleteForward": self.keyDelete,
-			"deleteBackward": self.keyBackspace,
-			"toggleOverwrite": self.keyToggleOW,
-			"pageUp": self.keyPageUp,
-			"pageDown": self.keyPageDown,
-			"1": self.keyNumberGlobal,
-			"2": self.keyNumberGlobal,
-			"3": self.keyNumberGlobal,
-			"4": self.keyNumberGlobal,
-			"5": self.keyNumberGlobal,
-			"6": self.keyNumberGlobal,
-			"7": self.keyNumberGlobal,
-			"8": self.keyNumberGlobal,
-			"9": self.keyNumberGlobal,
-			"0": self.keyNumberGlobal,
-			"file": self.keyFile
-		}, -1)  # To prevent left/right overriding the listbox.
-		self.onChangedEntry = []
-		self["VirtualKB"] = ActionMap(["VirtualKeyboardActions"], {
-			"showVirtualKeyboard": self.KeyText,
-		}, -2)
+		self.entryChanged = on_change if on_change is not None else lambda: None
+		if "key_menu" not in self:
+			self["key_menu"] = StaticText(_("MENU"))
+		if "key_red" not in self:
+			self["key_red"] = StaticText(_("Cancel"))
+		if "key_green" not in self:
+			self["key_green"] = StaticText(_("Save"))
+		if "key_help" not in self:
+			self["key_help"] = StaticText(_("HELP"))
+		if "HelpWindow" not in self:
+			self["HelpWindow"] = Pixmap()
+			self["HelpWindow"].hide()
+		if "VKeyIcon" not in self:
+			self["VKeyIcon"] = Boolean(False)
+		self["configActions"] = HelpableNumberActionMap(self, "ConfigListActions", {
+			"cancel": (self.keyCancel, _("Cancel any changed settings and exit")),
+			"close": (self.closeRecursive, _("Cancel any changed settings and exit all menus")),
+			"save": (self.keySave, _("Save all changed settings and exit")),
+			"select": (self.keySelect, _("Select, toggle, process or edit the current entry")),
+			"top": (self.keyTop, _("Move to first line")),
+			"pageUp": (self.keyPageUp, _("Move up a screen")),
+			"up": (self.keyUp, _("Move up a line")),
+			"first": (self.keyFirst, _("Jump to first item in list or the start of text")),
+			"left": (self.keyLeft, _("Select the previous item in list or move cursor left")),
+			"right": (self.keyRight, _("Select the next item in list or move cursor right")),
+			"last": (self.keyLast, _("Jump to last item in list or the end of text")),
+			"down": (self.keyDown, _("Move down a line")),
+			"pageDown": (self.keyPageDown, _("Move down a screen")),
+			"bottom": (self.keyBottom, _("Move to last line"))
+		}, prio=-1, description=_("Common Setup Functions"))
+		self["menuConfigActions"] = HelpableNumberActionMap(self, "ConfigListActions", {
+			"menu": (self.keyMenu, _("Display selection list as a selection menu")),
+		}, prio=-1, description=_("Common Setup Functions"))
+		self["menuConfigActions"].setEnabled(False)
+		self["textConfigActions"] = HelpableNumberActionMap(self, "ConfigListActions", {
+			"toggleOverwrite": (self.keyToggleOW, _("Toggle new text inserts before or overwrites existing text")),
+			"backspace": (self.keyBackspace, _("Delete the character to the left of cursor")),
+			"delete": (self.keyDelete, _("Delete the character under the cursor")),
+			"1": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"2": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"3": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"4": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"5": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"6": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"7": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"8": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"9": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"0": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"gotAsciiCode": (self.keyGotAscii, _("Keyboard data entry"))
+		}, prio=-1, description=_("Common Setup Functions"))
+		self["textConfigActions"].setEnabled(False)
+		self["VirtualKB"] = HelpableActionMap(self, "VirtualKeyboardActions", {
+			"showVirtualKeyboard": (self.keyText, _("Display the virtual keyboard for data entry"))
+		}, prio=-2, description=_("Common Setup Functions"))
 		self["VirtualKB"].setEnabled(False)
 		self["config"] = ConfigList(list, session=session)
-		if on_change is not None:
-			self.__changed = on_change
-		else:
-			self.__changed = lambda: None
+		self.cancelMsg = _("Really close without saving settings?")
+		self.onChangedEntry = []
 		if self.handleInputHelpers not in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.handleInputHelpers)
-		# self.onClose.append(self.__onClose)
+		if self.showHelpWindow not in self.onExecBegin:
+			self.onExecBegin.append(self.showHelpWindow)
+		if self.hideHelpWindow not in self.onExecEnd:
+			self.onExecEnd.append(self.hideHelpWindow)
 
-	# def __onClose(self):
-	# 	if "config" in self:
-	# 		self["config"].hideHelp()
-
+	# This should not be required if ConfigList is invoked via Setup (as it should).
+	#
 	def createSummary(self):
-		self.setup_title = self.getTitle()
+		# self.setup_title = self.getTitle()
 		from Screens.Setup import SetupSummary
 		return SetupSummary
 
@@ -184,124 +227,181 @@ class ConfigListScreen:
 	def getCurrentDescription(self):
 		return self["config"].getCurrent() and len(self["config"].getCurrent()) > 2 and self["config"].getCurrent()[2] or ""
 
+	def getCurrentItem(self):
+		return self["config"].getCurrent() and self["config"].getCurrent()[1] or None
+
+	def getCurrentSetting(self):
+		return self["config"].getCurrent() and str(self["config"].getCurrent()[1].value) or ""
+
 	def changedEntry(self):
 		for x in self.onChangedEntry:
 			x()
 
 	def handleInputHelpers(self):
-		if self["config"].getCurrent() is not None and self["config"].getCurrent()[1].__class__.__name__ in ('ConfigText', 'ConfigPassword'):
-			if "VKeyIcon" in self:
-				self["VirtualKB"].setEnabled(True)
-				self["VKeyIcon"].boolean = True
-			if "HelpWindow" in self and self["config"].getCurrent()[1].help_window and self["config"].getCurrent()[1].help_window.instance is not None:
-				helpwindowpos = self["HelpWindow"].getPosition()
-				from enigma import ePoint
-				self["config"].getCurrent()[1].help_window.instance.move(ePoint(helpwindowpos[0], helpwindowpos[1]))
-		elif "VKeyIcon" in self:
-				self["VirtualKB"].setEnabled(False)
-				self["VKeyIcon"].boolean = False
+		currConfig = self["config"].getCurrent()
+		if currConfig is not None:
+			if isinstance(currConfig[1], ConfigSelection):
+				self["menuConfigActions"].setEnabled(True)
+				self["key_menu"].setText(_("MENU"))
+			else:
+				self["menuConfigActions"].setEnabled(False)
+				self["key_menu"].setText("")
+			if isinstance(currConfig[1], ConfigText):
+				self["textConfigActions"].setEnabled(True)
+				self.showVKeyboard(True)
+				if "HelpWindow" in self and currConfig[1].help_window and currConfig[1].help_window.instance is not None:
+					helpwindowpos = self["HelpWindow"].getPosition()
+					currConfig[1].help_window.instance.move(ePoint(helpwindowpos[0], helpwindowpos[1]))
+			else:
+				self["textConfigActions"].setEnabled(False)
+				self.showVKeyboard(False)
 
-	def KeyText(self):
-		self["config"].hideHelp()
-		from Screens.VirtualKeyBoard import VirtualKeyBoard
-		self.session.openWithCallback(self.VirtualKeyBoardCallback, VirtualKeyBoard, title=self["config"].getCurrent()[0], text=self["config"].getCurrent()[1].value)
+	def showVKeyboard(self, state):
+		if "VKeyIcon" in self:
+			self["VirtualKB"].setEnabled(state)
+			self["VKeyIcon"].boolean = state
+
+	def showHelpWindow(self):
+		self.displayHelp(True)
+
+	def hideHelpWindow(self):
+		self.displayHelp(False)
+
+	def displayHelp(self, state):
+		if "config" in self and "HelpWindow" in self and self["config"].getCurrent() is not None:
+			currConf = self["config"].getCurrent()[1]
+			if isinstance(currConf, ConfigText) and currConf.help_window is not None and currConf.help_window.instance is not None:
+				if state:
+					currConf.help_window.show()
+				else:
+					currConf.help_window.hide()
+
+	def keyText(self):
+		self.session.openWithCallback(self.VirtualKeyBoardCallback, VirtualKeyBoard, title=self["config"].getCurrent()[0], text=str(self["config"].getCurrent()[1].value))
 
 	def VirtualKeyBoardCallback(self, callback=None):
 		if callback is not None:
-			self["config"].getCurrent()[1].setValue(callback)
-			self["config"].invalidate(self["config"].getCurrent())
-		self["config"].showHelp()
+			currConfig = self["config"].getCurrent()
+			prev = str(currConfig[1].value)
+			currConfig[1].setValue(callback)
+			self["config"].invalidate(currConfig)
+			if callback != prev:
+				# self["config"].changed()
+				self.entryChanged()
 
-	def keyOK(self):
-		self["config"].handleKey(KEY_OK)
+	def keySelect(self):
+		currConfig = self["config"].getCurrent()
+		if isinstance(currConfig[1], ConfigSelection):
+			self.keyMenu()
+		else:
+			self["config"].handleKey(KEYA_SELECT)
+
+	def keyOK(self):  # This is the deprecated version of keySelect!
+		self.keySelect()
+
+	def keyMenu(self):
+		currConfig = self["config"].getCurrent()
+		if currConfig and currConfig[1].enabled and hasattr(currConfig[1], "description"):
+			self.session.openWithCallback(
+				self.handleKeyMenuCallback, ChoiceBox, currConfig[0],
+				list=zip(currConfig[1].description, currConfig[1].choices),
+				selection=currConfig[1].choices.index(currConfig[1].value),
+				keys=[]
+			)
+
+	def handleKeyMenuCallback(self, answer):
+		if answer:
+			self["config"].getCurrent()[1].value = answer[1]
+			self["config"].invalidateCurrent()
+			self.entryChanged()
+
+	def keyFirst(self):
+		self["config"].handleKey(KEYA_HOME)
+		self.entryChanged()
+
+	def keyLast(self):
+		self["config"].handleKey(KEYA_END)
+		self.entryChanged()
 
 	def keyLeft(self):
-		self["config"].handleKey(KEY_LEFT)
-		self.__changed()
+		self["config"].handleKey(KEYA_LEFT)
+		self.entryChanged()
 
 	def keyRight(self):
-		self["config"].handleKey(KEY_RIGHT)
-		self.__changed()
+		self["config"].handleKey(KEYA_RIGHT)
+		self.entryChanged()
 
 	def keyHome(self):
-		self["config"].handleKey(KEY_HOME)
-		self.__changed()
+		self["config"].handleKey(KEYA_HOME)
+		self.entryChanged()
 
 	def keyEnd(self):
-		self["config"].handleKey(KEY_END)
-		self.__changed()
+		self["config"].handleKey(KEYA_END)
+		self.entryChanged()
 
 	def keyDelete(self):
-		self["config"].handleKey(KEY_DELETE)
-		self.__changed()
+		self["config"].handleKey(KEYA_DELETE)
+		self.entryChanged()
 
 	def keyBackspace(self):
-		self["config"].handleKey(KEY_BACKSPACE)
-		self.__changed()
+		self["config"].handleKey(KEYA_BACKSPACE)
+		self.entryChanged()
 
 	def keyToggleOW(self):
-		self["config"].handleKey(KEY_TOGGLEOW)
-		self.__changed()
+		self["config"].handleKey(KEYA_TOGGLEOW)
+		self.entryChanged()
 
 	def keyGotAscii(self):
-		self["config"].handleKey(KEY_ASCII)
-		self.__changed()
+		self["config"].handleKey(KEYA_ASCII)
+		self.entryChanged()
 
 	def keyNumberGlobal(self, number):
-		self["config"].handleKey(KEY_0 + number)
-		self.__changed()
+		self["config"].handleKey(KEYA_0 + number)
+		self.entryChanged()
 
-	def keyPageDown(self):
-		self["config"].pageDown()
+	def keyTop(self):
+		self["config"].moveTop()
+
+	def keyBottom(self):
+		self["config"].moveBottom()
 
 	def keyPageUp(self):
 		self["config"].pageUp()
 
-	def keyFile(self):
-		selection = self["config"].getCurrent()
-		if selection and selection[1].enabled and hasattr(selection[1], "description"):
-			self.session.openWithCallback(
-				self.handleKeyFileCallback, ChoiceBox, selection[0],
-				list=zip(selection[1].description, selection[1].choices),
-				selection=selection[1].choices.index(selection[1].value),
-				keys=[]
-			)
+	def keyPageDown(self):
+		self["config"].pageDown()
 
-	def handleKeyFileCallback(self, answer):
-		if answer:
-			self["config"].getCurrent()[1].value = answer[1]
-			self["config"].invalidateCurrent()
-			self.__changed()
+	def keyUp(self):
+		self["config"].moveUp()
+
+	def keyDown(self):
+		self["config"].moveDown()
+
+	def keySave(self):
+		self.saveAll()
+		self.close()
 
 	def saveAll(self):
 		for x in self["config"].list:
 			x[1].save()
 		configfile.save()
 
-	# keySave and keyCancel are just provided in case you need them.
-	# You have to call them by yourself.
-	#
-	def keySave(self):
-		self.saveAll()
-		self.close()
+	def keyCancel(self):
+		self.closeConfigList(False)
+
+	def closeRecursive(self):
+		self.closeConfigList(True)
+
+	def closeConfigList(self, recursiveClose=False):
+		if self["config"].isChanged():
+			self.recursiveClose = recursiveClose
+			self.session.openWithCallback(self.cancelConfirm, MessageBox, self.cancelMsg, default=False)
+		else:
+			self.close(recursiveClose)
 
 	def cancelConfirm(self, result):
 		if not result:
-			self["config"].showHelp()
 			return
 		for x in self["config"].list:
 			x[1].cancel()
-		self.close()
-
-	def closeMenuList(self, recursive=False):
-		if self["config"].isChanged():
-			self["config"].hideHelp()
-			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), default=False)
-		else:
-			self.close(recursive)
-
-	def keyCancel(self):
-		self.closeMenuList()
-
-	def closeRecursive(self):
-		self.closeMenuList(True)
+		self.close(self.recursiveClose)

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -153,8 +153,6 @@ class ConfigListScreen:
 			self["key_red"] = StaticText(_("Cancel"))
 		if "key_green" not in self:
 			self["key_green"] = StaticText(_("Save"))
-		if "key_help" not in self:
-			self["key_help"] = StaticText(_("HELP"))
 		if "HelpWindow" not in self:
 			self["HelpWindow"] = Pixmap()
 			self["HelpWindow"].hide()

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -6,6 +6,7 @@ from Screens.MessageBox import MessageBox
 from Screens.ChoiceBox import ChoiceBox
 import skin
 
+
 class ConfigList(GUIComponent, object):
 	def __init__(self, list, session=None):
 		GUIComponent.__init__(self)
@@ -57,22 +58,21 @@ class ConfigList(GUIComponent, object):
 		self.l.invalidateEntry(self.l.getCurrentSelectionIndex())
 
 	def invalidate(self, entry):
-		# when the entry to invalidate does not exist, just ignore the request.
-		# this eases up conditional setup screens a lot.
+		# When the entry to invalidate does not exist, just ignore the request.
+		# This eases up conditional setup screens a lot.
 		if entry in self.__list:
 			self.l.invalidateEntry(self.__list.index(entry))
 
 	GUI_WIDGET = eListbox
 
 	def selectionChanged(self):
-		if isinstance(self.current,tuple) and len(self.current) >= 2:
+		if isinstance(self.current, tuple) and len(self.current) >= 2:
 			self.current[1].onDeselect(self.session)
 		self.current = self.getCurrent()
-		if isinstance(self.current,tuple) and len(self.current) >= 2:
+		if isinstance(self.current, tuple) and len(self.current) >= 2:
 			self.current[1].onSelect(self.session)
 		else:
 			return
-
 		for x in self.onSelectionChanged:
 			x()
 
@@ -99,7 +99,6 @@ class ConfigList(GUIComponent, object):
 		self.timer.stop()
 		self.__list = l
 		self.l.setList(self.__list)
-
 		if l is not None:
 			for x in l:
 				assert len(x) < 2 or isinstance(x[1], ConfigElement), "entry in ConfigList " + str(x[1]) + " must be a ConfigElement"
@@ -126,6 +125,7 @@ class ConfigList(GUIComponent, object):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.pageDown)
 
+
 class ConfigListScreen:
 	def __init__(self, list, session=None, on_change=None):
 		self["config_actions"] = NumberActionMap(["SetupActions", "InputAsciiActions", "KeyboardInputActions"], {
@@ -151,30 +151,24 @@ class ConfigListScreen:
 			"9": self.keyNumberGlobal,
 			"0": self.keyNumberGlobal,
 			"file": self.keyFile
-		}, -1)  # to prevent left/right overriding the listbox
-
+		}, -1)  # To prevent left/right overriding the listbox.
 		self.onChangedEntry = []
-
 		self["VirtualKB"] = ActionMap(["VirtualKeyboardActions"], {
 			"showVirtualKeyboard": self.KeyText,
 		}, -2)
 		self["VirtualKB"].setEnabled(False)
-
 		self["config"] = ConfigList(list, session=session)
-
 		if on_change is not None:
 			self.__changed = on_change
 		else:
 			self.__changed = lambda: None
-
 		if self.handleInputHelpers not in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.handleInputHelpers)
+		# self.onClose.append(self.__onClose)
 
-#		self.onClose.append(self.__onClose)
-
-#	def __onClose(self):
-#		if "config" in self:
-#			self["config"].hideHelp()
+	# def __onClose(self):
+	# 	if "config" in self:
+	# 		self["config"].hideHelp()
 
 	def createSummary(self):
 		self.setup_title = self.getTitle()
@@ -285,7 +279,8 @@ class ConfigListScreen:
 		configfile.save()
 
 	# keySave and keyCancel are just provided in case you need them.
-	# you have to call them by yourself.
+	# You have to call them by yourself.
+	#
 	def keySave(self):
 		self.saveAll()
 		self.close()
@@ -294,7 +289,6 @@ class ConfigListScreen:
 		if not result:
 			self["config"].showHelp()
 			return
-
 		for x in self["config"].list:
 			x[1].cancel()
 		self.close()
@@ -302,7 +296,7 @@ class ConfigListScreen:
 	def closeMenuList(self, recursive=False):
 		if self["config"].isChanged():
 			self["config"].hideHelp()
-			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), default = False)
+			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), default=False)
 		else:
 			self.close(recursive)
 

--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -1,4 +1,4 @@
-from boxbranding import getBoxType, getBrandOEM, getDisplayType, getHaveAVJACK, getHaveHDMIinFHD, getHaveHDMIinHD, getHaveRCA, getHaveSCART, getHaveYUV, getMachineBuild, getMachineMtdRoot
+from boxbranding import getBoxType, getBrandOEM, getDisplayType, getHaveAVJACK, getHaveHDMIinFHD, getHaveHDMIinHD, getHaveRCA, getHaveSCART, getHaveYUV, getMachineBrand, getMachineBuild, getMachineMtdRoot, getMachineName
 from enigma import Misc_Options, eDVBCIInterfaces, eDVBResourceManager
 
 from Components.About import getChipSetString
@@ -23,6 +23,8 @@ def countFrontpanelLEDs():
 	return numLeds
 
 
+SystemInfo["MachineBrand"] = getMachineBrand()
+SystemInfo["MachineName"] = getMachineName()
 SystemInfo["CommonInterface"] = eDVBCIInterfaces.getInstance().getNumOfSlots()
 SystemInfo["CommonInterfaceCIDelay"] = fileCheck("/proc/stb/tsmux/rmx_delay")
 for cislot in range(0, SystemInfo["CommonInterface"]):

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -7,8 +7,53 @@ from copy import copy as copy_copy
 from os import path as os_path
 from time import localtime, strftime
 
-# ConfigElement, the base class of all ConfigElements.
+KEYA_LEFT = 0
+KEYA_RIGHT = 1
+KEYA_SELECT = 2
+KEYA_DELETE = 3
+KEYA_BACKSPACE = 4
+KEYA_HOME = 5
+KEYA_END = 6
+KEYA_TOGGLEOW = 7
+KEYA_ASCII = 8
+KEYA_TIMEOUT = 9
+KEYA_NUMBERS = range(12, 12 + 10)
+KEYA_0 = 12
+KEYA_1 = 13
+KEYA_2 = 14
+KEYA_3 = 15
+KEYA_4 = 16
+KEYA_5 = 17
+KEYA_6 = 18
+KEYA_7 = 19
+KEYA_8 = 20
+KEYA_9 = 21
+KEYA_PAGEUP = 22
+KEYA_PAGEDOWN = 23
+KEYA_PREV = 24
+KEYA_NEXT = 25
 
+# Deprecated / Legacy action key names...
+#
+# (These should be removed when all Enigma2 uses the new and less confusing names.)
+#
+KEY_LEFT = KEYA_LEFT
+KEY_RIGHT = KEYA_RIGHT
+KEY_OK = KEYA_SELECT
+KEY_DELETE = KEYA_DELETE
+KEY_BACKSPACE = KEYA_BACKSPACE
+KEY_HOME = KEYA_HOME
+KEY_END = KEYA_END
+KEY_TOGGLEOW = KEYA_TOGGLEOW
+KEY_ASCII = KEYA_ASCII
+KEY_TIMEOUT = KEYA_TIMEOUT
+KEY_NUMBERS = KEYA_NUMBERS
+KEY_0 = KEYA_0
+KEY_9 = KEYA_9
+
+
+# ConfigElement, the base class of all ConfigElements.
+#
 # it stores:
 #   value    the current value, usefully encoded.
 #            usually a property which retrieves _value,
@@ -193,21 +238,6 @@ class ConfigElement(object):
 		for extra_arg in self.extra_args:
 			if extra_arg[0] == notifier:
 				return extra_arg[1]
-
-
-KEY_LEFT = 0
-KEY_RIGHT = 1
-KEY_OK = 2
-KEY_DELETE = 3
-KEY_BACKSPACE = 4
-KEY_HOME = 5
-KEY_END = 6
-KEY_TOGGLEOW = 7
-KEY_ASCII = 8
-KEY_TIMEOUT = 9
-KEY_NUMBERS = range(12, 12 + 10)
-KEY_0 = 12
-KEY_9 = 12 + 9
 
 def getKeyNumber(key):
 	assert key in KEY_NUMBERS

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -129,6 +129,9 @@ class ConfigElement(object):
 	def tostring(self, value):
 		return str(value)
 
+	def toDisplayString(self, value):
+		return str(value)
+
 	# you need to override this if str(self.value) doesn't work
 	def save(self):
 		if self.save_disabled or (self.value == self.default and not self.save_forced):
@@ -394,6 +397,9 @@ class ConfigSelection(ConfigElement):
 	def tostring(self, val):
 		return str(val)
 
+	def toDisplayString(self, val):
+		return self.description[val]
+
 	def getValue(self):
 		return self._value
 
@@ -499,6 +505,9 @@ class ConfigBoolean(ConfigElement):
 			return "False"
 		else:
 			return "True"
+
+	def toDisplayString(self, value):
+		return self.descriptions[True] if value or str(value).lower() in ["true", self.descriptions[True].lower()] else self.descriptions[False]
 
 	def fromstring(self, val):
 		if str(val).lower() == "true":

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -27,28 +27,26 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 	def __init__(self, session, setup, plugin=None, PluginLanguageDomain=None):
 		Screen.__init__(self, session)
 		HelpableScreen.__init__(self)
-		# for the skin: first try a setup_<setupID>, then Setup
-		self.skinName = ["setup_" + setup, "Setup"]
-		self.onChangedEntry = []
-		self.item = None
-		self.list = []
-		self.force_update_list = False
+		self.setup = setup
 		self.plugin = plugin
 		self.PluginLanguageDomain = PluginLanguageDomain
-		self.setup = {}
-		xmldata = setupDom(setup, self.plugin).getroot()
-		for x in xmldata.findall("setup"):
-			if x.get("key") == setup:
-				self.setup = x
-				break
+		self.onChangedEntry = []
+		if hasattr(self, "skinName"):
+			if not isinstance(self.skinName, list):
+				self.skinName = [self.skinName]
+		else:
+			self.skinName = []
+		if setup:
+			self.skinName.append("Setup_%s" % setup)
+		self.skinName.append("Setup")
 		if config.usage.show_menupath.value in ("large", "small") and x.get("titleshort", "").encode("UTF-8") != "":
 			title = x.get("titleshort", "").encode("UTF-8")
 		else:
 			title = x.get("title", "").encode("UTF-8")
 		title = _("Setup" if title == "" else title)
 		self.setTitle(title)
-		self.seperation = int(self.setup.get("separation", "0"))
 		self.footnote = ""
+		self.list = []
 		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry)
 		self["footnote"] = Label()
 		self["footnote"].hide()

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -1,37 +1,38 @@
-from Screens.Screen import Screen
-from Components.ActionMap import NumberActionMap
-from Components.config import config, ConfigNothing, ConfigBoolean, ConfigSelection
-from Tools.Directories import resolveFilename, SCOPE_CURRENT_PLUGIN
-from Components.SystemInfo import SystemInfo
-from Components.ConfigList import ConfigListScreen
-from Components.Pixmap import Pixmap
-from Components.Sources.StaticText import StaticText
-from Components.Label import Label
-from Components.Sources.Boolean import Boolean
+import xml.etree.cElementTree
 
+from boxbranding import getMachineBrand, getMachineName
 from enigma import eEnv
 from gettext import dgettext
-from boxbranding import getMachineBrand, getMachineName
 
-import xml.etree.cElementTree
+from Components.ActionMap import NumberActionMap
+from Components.config import ConfigBoolean, ConfigNothing, ConfigSelection, config
+from Components.ConfigList import ConfigListScreen
+from Components.Label import Label
+from Components.Pixmap import Pixmap
+from Components.SystemInfo import SystemInfo
+from Components.Sources.Boolean import Boolean
+from Components.Sources.StaticText import StaticText
+from Screens.Screen import Screen
+from Tools.Directories import SCOPE_CURRENT_PLUGIN, resolveFilename
 
 def setupdom(plugin=None):
 	# read the setupmenu
 	if plugin:
 		# first we search in the current path
-		setupfile = file(resolveFilename(SCOPE_CURRENT_PLUGIN, plugin + '/setup.xml'), 'r')
+		setupfile = file(resolveFilename(SCOPE_CURRENT_PLUGIN, plugin + "/setup.xml"), "r")
 	else:
 		# if not found in the current path, we use the global datadir-path
-		setupfile = file(eEnv.resolve('${datadir}/enigma2/setup.xml'), 'r')
+		setupfile = file(eEnv.resolve("${datadir}/enigma2/setup.xml"), "r")
 	setupfiledom = xml.etree.cElementTree.parse(setupfile)
 	setupfile.close()
 	return setupfiledom
 
 def getConfigMenuItem(configElement):
-	for item in setupdom().getroot().findall('./setup/item/.'):
+	for item in setupdom().getroot().findall("./setup/item/."):
 		if item.text == configElement:
 			return _(item.attrib["text"]), eval(configElement)
 	return "", None
+
 
 class SetupError(Exception):
 	def __init__(self, message):
@@ -40,90 +41,82 @@ class SetupError(Exception):
 	def __str__(self):
 		return self.msg
 
+
 class SetupSummary(Screen):
 	def __init__(self, session, parent):
-		Screen.__init__(self, session, parent = parent)
+		Screen.__init__(self, session, parent=parent)
 		self["SetupTitle"] = StaticText(parent.getTitle())
 		self["SetupEntry"] = StaticText("")
 		self["SetupValue"] = StaticText("")
-		if hasattr(self.parent,"onChangedEntry"):
+		if hasattr(self.parent, "onChangedEntry"):
 			self.onShow.append(self.addWatcher)
 			self.onHide.append(self.removeWatcher)
 
 	def addWatcher(self):
-		if hasattr(self.parent,"onChangedEntry"):
+		if hasattr(self.parent, "onChangedEntry"):
 			self.parent.onChangedEntry.append(self.selectionChanged)
 			self.parent["config"].onSelectionChanged.append(self.selectionChanged)
 			self.selectionChanged()
 
 	def removeWatcher(self):
-		if hasattr(self.parent,"onChangedEntry"):
+		if hasattr(self.parent, "onChangedEntry"):
 			self.parent.onChangedEntry.remove(self.selectionChanged)
 			self.parent["config"].onSelectionChanged.remove(self.selectionChanged)
 
 	def selectionChanged(self):
 		self["SetupEntry"].text = self.parent.getCurrentEntry()
 		self["SetupValue"].text = self.parent.getCurrentValue()
-		if hasattr(self.parent,"getCurrentDescription") and "description" in self.parent:
+		if hasattr(self.parent, "getCurrentDescription") and "description" in self.parent:
 			self.parent["description"].text = self.parent.getCurrentDescription()
-		if self.parent.has_key('footnote'):
-			if self.parent.getCurrentEntry().endswith('*'):
-				self.parent['footnote'].text = (_("* = Restart Required"))
+		if "footnote" in self.parent:
+			if self.parent.getCurrentEntry().endswith("*"):
+				self.parent["footnote"].text = (_("* = Restart Required"))
 			else:
-				self.parent['footnote'].text = ("")
+				self.parent["footnote"].text = ("")
+
 
 class Setup(ConfigListScreen, Screen):
-
 	ALLOW_SUSPEND = True
 
 	def __init__(self, session, setup, plugin=None, PluginLanguageDomain=None):
 		Screen.__init__(self, session)
 		# for the skin: first try a setup_<setupID>, then Setup
-		self.skinName = ["setup_" + setup, "Setup" ]
-
-		self['footnote'] = Label()
+		self.skinName = ["setup_" + setup, "Setup"]
+		self["footnote"] = Label()
 		self["HelpWindow"] = Pixmap()
 		self["HelpWindow"].hide()
 		self["VKeyIcon"] = Boolean(False)
-		self.onChangedEntry = [ ]
+		self.onChangedEntry = []
 		self.item = None
 		self.list = []
 		self.force_update_list = False
 		self.plugin = plugin
 		self.PluginLanguageDomain = PluginLanguageDomain
 		self.setup = {}
-
 		xmldata = setupdom(self.plugin).getroot()
 		for x in xmldata.findall("setup"):
 			if x.get("key") == setup:
 				self.setup = x
 				break
-
-		if config.usage.show_menupath.value in ('large', 'small') and x.get("titleshort", "").encode("UTF-8") != "":
+		if config.usage.show_menupath.value in ("large", "small") and x.get("titleshort", "").encode("UTF-8") != "":
 			title = x.get("titleshort", "").encode("UTF-8")
 		else:
 			title = x.get("title", "").encode("UTF-8")
 		title = _("Setup" if title == "" else title)
 		self.setTitle(title)
-		self.seperation = int(self.setup.get('separation', '0'))
-
-		ConfigListScreen.__init__(self, self.list, session = session, on_change = self.changedEntry)
+		self.seperation = int(self.setup.get("separation", "0"))
+		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry)
 		self.createSetupList()
 		self["config"].onSelectionChanged.append(self.__onSelectionChanged)
-
-		#check for list.entries > 0 else self.close
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText(_("Save"))
 		self["description"] = Label("")
-
-		self["actions"] = NumberActionMap(["SetupActions", "MenuActions"],
-			{
-				"cancel": self.keyCancel,
-				"save": self.keySave,
-				"menu": self.closeRecursive,
-			}, -2)
-
-		if not self.handleInputHelpers in self["config"].onSelectionChanged:
+		self["actions"] = NumberActionMap(["SetupActions", "MenuActions"], {
+			"cancel": self.keyCancel,
+			"save": self.keySave,
+			"menu": self.closeRecursive,
+		}, -2)
+		if self.handleInputHelpers not in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.handleInputHelpers)
 		self.changedEntry()
 
@@ -133,15 +126,13 @@ class Setup(ConfigListScreen, Screen):
 		for x in self.setup:
 			if not x.tag:
 				continue
-			if x.tag == 'item':
+			if x.tag == "item":
 				item_level = int(x.get("level", 0))
-
 				if item_level > config.usage.setup_level.index:
 					continue
-
 				requires = x.get("requires")
-				if requires and not requires.startswith('config.'):
-					if requires.startswith('!'):
+				if requires and not requires.startswith("config."):
+					if requires.startswith("!"):
 						if SystemInfo.get(requires[1:], False):
 							continue
 					elif not SystemInfo.get(requires, False):
@@ -149,26 +140,23 @@ class Setup(ConfigListScreen, Screen):
 				conditional = x.get("conditional")
 				if conditional and not eval(conditional):
 					continue
-
 				# this block is just for backwards compatibility
-				if requires and requires.startswith('config.'):
+				if requires and requires.startswith("config."):
 					item = eval(requires)
 					if not (item.value and not item.value == "0"):
 						continue
-
 				if self.PluginLanguageDomain:
 					item_text = dgettext(self.PluginLanguageDomain, x.get("text", "??").encode("UTF-8"))
 					item_description = dgettext(self.PluginLanguageDomain, x.get("description", " ").encode("UTF-8"))
 				else:
 					item_text = _(x.get("text", "??").encode("UTF-8"))
 					item_description = _(x.get("description", " ").encode("UTF-8"))
-
-				item_text = item_text.replace("%s %s","%s %s" % (getMachineBrand(), getMachineName()))
-				item_description = item_description.replace("%s %s","%s %s" % (getMachineBrand(), getMachineName()))
+				item_text = item_text.replace("%s %s", "%s %s" % (getMachineBrand(), getMachineName()))
+				item_description = item_description.replace("%s %s", "%s %s" % (getMachineBrand(), getMachineName()))
 				b = eval(x.text or "")
 				if b == "":
 					continue
-				#add to configlist
+				# add to configlist
 				item = b
 				# the first b is the item itself, ignored by the configList.
 				# the second one is converted to string.

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -5,14 +5,13 @@ from gettext import dgettext
 from os.path import getmtime, join as pathJoin
 from skin import setups
 
-from Components.ActionMap import NumberActionMap
 from Components.config import ConfigBoolean, ConfigNothing, ConfigSelection, config
 from Components.ConfigList import ConfigListScreen
 from Components.Label import Label
 from Components.Pixmap import Pixmap
 from Components.SystemInfo import SystemInfo
-from Components.Sources.Boolean import Boolean
 from Components.Sources.StaticText import StaticText
+from Screens.HelpMenu import HelpableScreen
 from Screens.Screen import Screen
 from Tools.Directories import SCOPE_CURRENT_SKIN, SCOPE_PLUGINS, SCOPE_SKIN, resolveFilename
 from Tools.LoadPixmap import LoadPixmap
@@ -22,11 +21,12 @@ setupModTimes = {}
 setupTitles = {}
 
 
-class Setup(ConfigListScreen, Screen):
+class Setup(ConfigListScreen, Screen, HelpableScreen):
 	ALLOW_SUSPEND = True
 
 	def __init__(self, session, setup, plugin=None, PluginLanguageDomain=None):
 		Screen.__init__(self, session)
+		HelpableScreen.__init__(self)
 		# for the skin: first try a setup_<setupID>, then Setup
 		self.skinName = ["setup_" + setup, "Setup"]
 		self.onChangedEntry = []
@@ -52,9 +52,7 @@ class Setup(ConfigListScreen, Screen):
 		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry)
 		self["footnote"] = Label()
 		self["footnote"].hide()
-		self["HelpWindow"] = Pixmap()
-		self["HelpWindow"].hide()
-		self["VKeyIcon"] = Boolean(False)
+		self["description"] = Label()
 		defaultmenuimage = setups.get("default", "")
 		menuimage = setups.get(setup, defaultmenuimage)
 		if menuimage:
@@ -71,14 +69,6 @@ class Setup(ConfigListScreen, Screen):
 		if self.layoutFinished not in self.onLayoutFinish:
 			self.onLayoutFinish.append(self.layoutFinished)
 		self["config"].onSelectionChanged.append(self.__onSelectionChanged)
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
-		self["description"] = Label("")
-		self["actions"] = NumberActionMap(["SetupActions", "MenuActions"], {
-			"cancel": self.keyCancel,
-			"save": self.keySave,
-			"menu": self.closeRecursive,
-		}, -2)
 		if self.handleInputHelpers not in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.handleInputHelpers)
 		self.changedEntry()


### PR DESCRIPTION
[Setup.py] PEP8 clean up before refactor

[ConfigList.py] PEP8 clean up prior to enhancement
- This code will be enhanced to take on parts of Setup.py that are more appropriately located here.

[Setup.py] Reorganise code
- Move some code blocks around to improve layout and prepare for enhancements.

[Setup.py] Enhance setup dom processing
- Use caching logic to cache the setup.xml file dom.
- Temporarily retain the old dom for compatibility with external code.
- Extract a dictionary of Setup screen titles to optimise title generation.

[Setup.py] Move processing from Summary to main code
- Move processing of the "description" and "footnote" widgets from the "SetupSummary" to the main "Setup" class.

[Setup.py] Add Setup menu image facility
- Add a way to have images associated with each Setup menu screen.  These images are defined in the skin via the "<setups>" block previously added during the "skin.py" refactor.

  If a specific Setup menu does not have an image defined then a generic "default" image, if available, will be used.  If no images are defined then no "menuimage" widget is created.  For consistency if Setup screen menu images are desired then it is appropriate to ensure that a "default" image is defined and available.

  Any skin can have a "<setups>" block contains lines of "<setup>" tags that each contain a "key" attribute is the same as the setup.xml "key" attribute and a "name" attribute is the image file to be used for that Setup screen.

[Setup.py] Add help and move remote buttons
- Add access to the HELP screen function.
- Move the remote button processing to ConfigList.py.
- Move the skin button related widgets to ConfigList.py.

[ConfigList.py] Enhance code functionality
- Reorganise and optimise imports.
- Rename "KEY_xxx" imports to "KEYA_xxx" as these are *NOT* related to the remote control buttons but are rather an interface between "ConfigList.py" and "config.py" for button actions.
- Move the helper window control from the "ConfigList" class to the "ConfigListScreen" where it is more effectively used.
- Add more navigation options (moveTop, moveBotton, moveUp, moveDown) for the "config" widget list.
- Enhance the helper window controls to incorporate the code from the "ConfigList" class to display the TEXT button prompt on test based configuration items and to now also display the MENU button prompt if a "ConfigSelection" list can be expanded to a pop up selection list by pressing the MENU button.
- Expand the ActionMaps to account for all the new navigation options.  Also separate the action maps so that buttons that are inappropriate for a particular "ConfigElement" class are disabled and display the appropriate invalid button pop up.
- Conditionally define any required skin widgets are not yet defined.
- Tidy up the "on_change" processing.
- Allow the user to long press EXIT to recursively close all Setup menus.
- Move the settings change cancel message to a separate variable so that the message can be changed in any class based on the "Setup" or ""ConfigListScreen" classes.

[keymap.xml] Add keymap for refactored ConfigList

[config.py] Adjust "KEY_xxx" button action names
- The button actions that link "ConfigList.py" and "config.py" were defined with "KEY_xxx" names.  This can easily be confused with remote control button key codes.  To clarify the distinction all "KEY_xxx" button actions will progressively be renamed "KEYA_xxx" to remind coders that these describe actions and not button key codes.

[Setup.py] Improve skin name processing
- Improve the skin name selection processing logic.
- Tidy up some more left over code.

[Setup.py] Refactor config list construction code
- Optimise the code to generate the config list entries.
- Add logic to not reload the config list if no changes are required.
- Convert internal variables to camelCase.
- Add a new facility to display the default value of each config entry.
- Add a log message if a setup menu has no eligible entries.

[config.py] Add methods to display default values
- Add the "toDisplayString()" methods to allow the new Setup.py to display the default values for all config entries.

[SystemInfo.py] Add box brand and name definitions
- This change add the "boxbranding" definitions of "getMachineBrand()" and "getMachineName()" as SystemInfo dictionary entries "MachineBrand" and "MachineName" respectively.  This abstraction allows the same code that requires this information to run on all images of Enigma2.

[setup.xml] Rename titleshort attribute
- Rename the "titleshort" attribute to "menuTitle" to:
  a) better reflect the meaning and usage of the attribute, and
  b) camelCase the variable.

[SETUP] Add new guide to explain refactored Setup code

UPDATE:

[ConfigList.py] Don't force display the HELP button
- This change fixes an issue where the HELP button was being enabled even if the host class does not include the "HelpableScreen" class.
