### PR TITLE
[config.py] Fix index into ConfigSelection lists

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -289,7 +289,7 @@ class choicesList(object):  # XXX: we might want a better name for this
 
 	def index(self, value):
 		try:
-			return self.__list__().index(value)
+			return self.__list__().index(str(value))
 		except (ValueError, IndexError):
 			# occurs e.g. when default is not in list
 			return 0


### PR DESCRIPTION
Keys for the ConfigSelection lists are all, by definition, strings.  The index method did not ensure a string type in searching the list so could fail to find the item if it was numeric.  Casting to string solves the issue.
