### PR TITLE
[InstallWizard.py] Correct session open arguments

### DIFF
--- a/lib/python/Screens/InstallWizard.py
+++ b/lib/python/Screens/InstallWizard.py
@@ -109,10 +109,10 @@ class InstallWizard(Screen, ConfigListScreen):
 			self.session.open(InstallWizardIpkgUpdater, self.index, _('Please wait (downloading channel list)'), IpkgComponent.CMD_REMOVE, {'package': 'enigma2-plugin-settings-henksat-' + self.channellist_type.value})
 		elif self.index == self.INSTALL_PLUGINS and self.enabled.value:
 			from PluginBrowser import PluginDownloadBrowser
-			self.session.open(PluginDownloadBrowser, 0, True, "", "PluginDownloadBrowserWizard")
+			self.session.open(PluginDownloadBrowser, 0, True, "PluginDownloadBrowserWizard")
 		elif self.index == self.INSTALL_SKINS and self.enabled.value:
 			from SkinSelector import SkinSelector
-			self.session.open(SkinSelector, "", "SkinSelectorWizard")
+			self.session.open(SkinSelector, "SkinSelectorWizard")
 		return
 
 class InstallWizardIpkgUpdater(Screen):


### PR DESCRIPTION
The "" placeholders are left overs from the previous menu_path processing.
