### PR TITLE
More improvements to Setup system

### DIFF
--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -162,15 +162,15 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 			self["footnote"].text = footnote
 			self["footnote"].show()
 
+	def getFootnote(self):
+		return self["footnote"].text
+
 	def moveToItem(self, item):
 		if item != self["config"].getCurrent():
 			self["config"].setCurrentIndex(self.getIndexFromItem(item))
 
 	def getIndexFromItem(self, item):
 		return self["config"].list.index(item) if item in self["config"].list else 0
-
-	def run(self):
-		self.keySave()
 
 
 class SetupSummary(Screen):


### PR DESCRIPTION
[Setup.py] Additional improvements
- Add getFootnote() method to return the current footnote.
- Move the run() method to ConfigList.py to allow the Wizard to save any ConfigList based screen.

[ConfigList.py] Additional improvements
- Add methods to allow the cancel and restart messages to be changed or reset back to default.
- Optimise some code and improve readability.
- Add code to trigger the GUI restart option screen if any entries tagged as requiring a restart are changed.
- Add the run() method to ConfigList.py to allow the Wizard to save any ConfigList based screen.
