### PR TITLE
Make geolocation user controlled in a new Time Setup screen

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -166,7 +166,7 @@ self.session.open(SABnzbdSetupScreen)
 				<item level="0" text="Filesystem check" entryID="harddisk_check"><screen module="HarddiskSetup" screen="HarddiskFsckSelection"/></item>
 			</menu>
 			<!-- Menu / Setup / Time Settings -->
-			<item level="0" entryID="time_setup"><setup id="time"/></item>
+			<item level="0" text="Time" entryID="time_setup"><screen module="Time" screen="Time" /></item>
 			<!-- Menu / Setup / Recordings, Playback & Timeshift -->
 			<menu weight="11" level="1" text="Recordings, playback &amp; timeshift" entryID="rec_setup">
 			 	<id val="rec" />

--- a/lib/python/Screens/Time.py
+++ b/lib/python/Screens/Time.py
@@ -1,0 +1,54 @@
+from Components.ActionMap import HelpableActionMap
+from Components.config import config
+from Components.Sources.StaticText import StaticText
+from Screens.Setup import Setup
+from Tools.Geolocation import geolocation
+
+
+class Time(Setup):
+	def __init__(self, session, PluginLanguageDomain=None):
+		Setup.__init__(self, session=session, setup="time", plugin=None, PluginLanguageDomain=PluginLanguageDomain)
+		self["key_yellow"] = StaticText("")
+		self["geolocationActions"] = HelpableActionMap(self, "ColorActions", {
+			"yellow": (self.useGeolocation, _("Use geolocation to set the current time zone location"))
+		}, prio=0, description=_("Time Setup Actions"))
+		self.selectionChanged()
+
+	def selectionChanged(self):
+		if Setup.getCurrentItem(self) in (config.timezone.area, config.timezone.val):
+			self["key_yellow"].setText(_("Use Geolocation"))
+			self["geolocationActions"].setEnabled(True)
+		else:
+			self["key_yellow"].setText("")
+			self["geolocationActions"].setEnabled(False)
+		Setup.selectionChanged(self)
+
+	def useGeolocation(self):
+		geoData = geolocation.getGeolocationData(fields="status,message,timezone,proxy")
+		if geoData.get("proxy", True):
+			self.setFootnote(_("Geolocation is not available."))
+			return
+		tz = geoData.get("timezone", None)
+		if tz is None:
+			self.setFootnote(_("Geolocation does not contain time zone information."))
+		else:
+			areaItem = None
+			valItem = None
+			for item in self["config"].list:
+				if item[1] == config.timezone.area:
+					areaItem = item
+				if item[1] == config.timezone.val:
+					valItem = item
+			area, zone = tz.split("/", 1)
+			config.timezone.area.value = area
+			if areaItem is not None:
+				areaItem[1].changed()
+			self["config"].invalidate(areaItem)
+			config.timezone.val.value = zone
+			if valItem is not None:
+				valItem[1].changed()
+			self["config"].invalidate(valItem)
+			self.setFootnote(_("Geolocation has been used to set the time zone."))
+
+	def yellow(self):  # Invoked from the Wizard.
+		self.useGeolocation()

--- a/lib/python/Tools/Geolocation.py
+++ b/lib/python/Tools/Geolocation.py
@@ -1,13 +1,11 @@
 from json import loads
 from urllib2 import URLError, urlopen
 
-from Components.config import ConfigYesNo, config
-
 # Data available from http://ip-api.com/json/:
 #
 # 	Name		Description				Example			Type
 # 	--------------	--------------------------------------	----------------------	------
-# 	status		success or fail				success			string
+# 	status		"success" or "fail"			success			string
 # 	message		Included only when status is fail. Can
 # 			be one of the following: private range,
 # 			reserved range, invalid query		invalid query		string
@@ -24,6 +22,7 @@ from Components.config import ConfigYesNo, config
 # 	lat		Latitude				37.4192			float
 # 	lon		Longitude				-122.0574		float
 # 	timezone	City timezone				America/Los_Angeles	string
+# 	offset		Timezone UTC DST offset in seconds	-25200			int
 # 	currency	National currency			USD			string
 # 	isp		ISP name				Google			string
 # 	org		Organization name			Google			string
@@ -32,46 +31,92 @@ from Components.config import ConfigYesNo, config
 # 			not being announced in BGP tables.	AS15169 Google Inc.	string
 # 	asname		AS name (RIR). Empty for IP blocks not
 # 			being announced in BGP tables.		GOOGLE			string
-# 	reverse		Reverse DNS of the IP
-# 			(Not fetched as it delays response)	wi-in-f94.1e100.net	string
+# 	reverse		Reverse DNS of the IP			wi-in-f94.1e100.net	string
+# 			(Warning: Requesting this field can delay response!)
 # 	mobile		Mobile (cellular) connection		true			bool
 # 	proxy		Proxy, VPN or Tor exit address		true			bool
 # 	hosting		Hosting, colocated or data center	true			bool
 # 	query		IP used for the query			173.194.67.94		string
 
-config.misc.enableGeolocation = ConfigYesNo(default=True)
-geolocation = {}
+geolocationFields = {
+	"country": 0x00000001,
+	"countryCode": 0x00000002,
+	"region": 0x00000004,
+	"regionName": 0x00000008,
+	"city": 0x00000010,
+	"zip": 0x00000020,
+	"lat": 0x00000040,
+	"lon": 0x00000080,
+	"timezone": 0x00000100,
+	"isp": 0x00000200,
+	"org": 0x00000400,
+	"as": 0x00000800,
+	"reverse": 0x00001000,
+	"query": 0x00002000,
+	"status": 0x00004000,
+	"message": 0x00008000,
+	"mobile": 0x00010000,
+	"proxy": 0x00020000,
+	# "": 0x00040000,
+	"district": 0x00080000,
+	"continent": 0x00100000,
+	"continentCode": 0x00200000,
+	"asname": 0x00400000,
+	"currency": 0x00800000,
+	"hosting": 0x01000000,
+	"offset": 0x02000000
+}
 
-def InitGeolocation():
-	global geolocation
-	if config.misc.enableGeolocation.value:
-		if len(geolocation) == 0:
-			try:
-				response = urlopen("http://ip-api.com/json/?fields=3326223", data=None, timeout=10).read()
-				# print "[Geolocation] DEBUG:", response
-				if response:
-					geolocation = loads(response)
-				status = geolocation.get("status", None)
-				if status and status == "success":
-					print "[Geolocation] Geolocation data initialised."
-					config.misc.enableGeolocation.value = False
-					config.misc.enableGeolocation.save()
-				else:
-					print "[Geolocation] Error: Geolocation lookup returned a '%s' status!  Message '%s' returned." % (status, geolocation.get("message", None))
-			except URLError as err:
-				if hasattr(err, 'code'):
-					print "[Geolocation] Error: Geolocation data not available! (Code: %s)" % err.code
-				if hasattr(err, 'reason'):
-					print "[Geolocation] Error: Geolocation data not available! (Reason: %s)" % err.reason
-			except ValueError:
-				print "[Geolocation] Error: Geolocation data returned can not be processed!"
+
+class Geolocation:
+	def __init__(self):
+		self.geolocation = {}
+		# self.getGeolocationData(fields=None)
+
+	def getGeolocationData(self, fields=None):
+		fields = self.fieldsToNumber(fields)
+		try:
+			response = urlopen("http://ip-api.com/json/?fields=%s" % fields, data=None, timeout=10).read()
+			# print("[Geolocation] DEBUG: '%s'." % str(response))
+			if response:
+				geolocation = loads(response)
+			status = geolocation.get("status", None)
+			if status and status == "success":
+				print("[Geolocation] Geolocation data retreived.")
+				for key in geolocation:
+					self.geolocation[key] = geolocation[key]
+				return self.geolocation
+			else:
+				print("[Geolocation] Error: Geolocation lookup returned a '%s' status!  Message '%s' returned." % (status, geolocation.get("message", None)))
+		except URLError as err:
+			if hasattr(err, 'code'):
+				print("[Geolocation] Error: Geolocation data not available! (Code: %s)" % err.code)
+			if hasattr(err, 'reason'):
+				print("[Geolocation] Error: Geolocation data not available! (Reason: %s)" % err.reason)
+		except ValueError:
+			print("[Geolocation] Error: Geolocation data returned can not be processed!")
+		return {}
+
+	def fieldsToNumber(self, fields):
+		if fields is None:
+			fields = [x for x in geolocationFields]
+		elif isinstance(fields, str):
+			fields = [x.strip() for x in fields.split(",")]
+		if isinstance(fields, int):
+			number = fields
 		else:
-			print "[Geolocation] Note: Geolocation has already been run for this boot."
-	else:
-		geolocation = {}
-		print "[Geolocation] Warning: Geolocation has been disabled by user configuration!"
+			number = 0
+			for field in fields:
+				value = geolocationFields.get(field, 0)
+				if value:
+					number |= value
+				else:
+					print("[Geolocation] Warning: Ignoring invalid geolocation field '%s'!" % field)
+		# print("[Geolocation] DEBUG: Fields='%s' -> Number=%d." % (fields, number))
+		return number
 
-def RefreshGeolocation():
-	global geolocation
-	geolocation = {}
-	InitGeolocation()
+	def clearGeolocationData(self):
+		self.geolocation = {}
+
+
+geolocation = Geolocation()

--- a/mytest.py
+++ b/mytest.py
@@ -32,10 +32,6 @@ if getImageArch() in ("aarch64"):
 
 from traceback import print_exc
 
-profile("Geolocation")
-import Tools.Geolocation
-Tools.Geolocation.InitGeolocation()
-
 profile("ClientMode")
 import Components.ClientMode
 Components.ClientMode.InitClientMode()


### PR DESCRIPTION
[Time.py] Add new screen for setting the time
- This module uses the new Setup subsystem to set the time on the receiver.
- This code uses a refactored geolocation module.
- Geolocation is now *only* performed if the user requests a geolocation to be used to set the time zone.
- This code and geolocation setting is available in the Welcome Wizard.

[Geolocation.py] Refactor to on demand usage
- This code is now only run when permitted by a user request for geolocation data.
- Reorganise the code to match its new on-demand usage style.
- Allow the geolocation fields to be specified as a keyword or number list, comma separated keyword or number string.  (The value None is a shortcut for everything.)

[mytest.py] Remove geolocation initialisation
- The geolocation code is now run on demand.

[menu.xml] Use the new Time.py time setting UI

[Timezones.py] Remove geolocation functionality
- The geolocation functionality has been moved to the new time setup screen.
- Update the instructional comments.
- Make print statements Python 3 ready.

Please note that the temporary config variable "config.misc.enableGeolocation" is no longer used and can be removed.
