### PR TITLE
Add Erase function to ConfigText objects.

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -1,12 +1,255 @@
 <!--suppress XmlUnboundNsPrefix -->
-	<!-- Flag meanings in <key/> elements:
-		"m": action active on key "make"
-		"b": action active on key "break"
-		"r": action active on key repeats
-		"l": action on long keypress
+
+	<!--
+		Flag meanings in <key /> elements:
+		"m": Action active on key "Make".
+		"b": Action active on key "Break".
+		"r": Action active on key repeats.
+		"l": Action on long keypress.
 	-->
 
 <keymap>
+	<!--
+		These key map actions are global to all screens.  These
+		definitions should never be defeated or changed without
+		very careful consideration.
+	-->
+
+	<map context="GlobalActions">
+		<key id="KEY_VOLUMEUP" mapto="volumeUp" flags="mr" />
+		<key id="KEY_VOLUMEDOWN" mapto="volumeDown" flags="mr" />
+		<key id="KEY_MUTE" mapto="volumeMute" flags="m" /><!-- Was repeat appropriate for mute? -->
+		<key id="KEY_POWER" mapto="power_long" flags="l" />
+		<key id="KEY_POWER" mapto="power_down" flags="m" />
+		<key id="KEY_POWER" mapto="power_up" flags="b" />
+		<key id="KEY_KP0" mapto="discrete_off" flags="m" />
+		<device name="dreambox front panel">
+			<key id="KEY_POWER" mapto="deepstandby" flags="l" />
+		</device>
+	</map>
+
+	<!--
+		These are shared key maps that are used by multiple modules.
+		Please don't change any of these definitions without checking
+		all the code to ensure that there are no negative or other
+		undesirable side effects.
+	-->
+	<map context="HelpActions">
+		<key id="KEY_HELP" mapto="displayHelp" flags="b" />
+	</map>
+
+	<map context="NavigationActions">
+		<key id="KEY_REWIND" mapto="top" flags="m" />
+		<key id="KEY_CHANNELUP" mapto="pageUp" flags="mr" />
+		<key id="KEY_UP" mapto="up" flags="mr" />
+		<key id="KEY_PREVIOUS" mapto="first" flags="m" />
+		<key id="KEY_LEFT" mapto="left" flags="mr" />
+		<key id="KEY_RIGHT" mapto="right" flags="mr" />
+		<key id="KEY_NEXT" mapto="last" flags="m" />
+		<key id="KEY_DOWN" mapto="down" flags="mr" />
+		<key id="KEY_CHANNELDOWN" mapto="pageDown" flags="mr" />
+		<key id="KEY_FASTFORWARD" mapto="bottom" flags="m" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_HOME" mapto="top" flags="m" />
+		<key id="KEY_PAGEUP" mapto="pageUp" flags="mr" />
+		<key id="KEY_PREVIOUSSONG" mapto="first" flags="m" />
+		<key id="KEY_F9" mapto="first" flags="m" />
+		<key id="KEY_F10" mapto="last" flags="m" />
+		<key id="KEY_NEXTSONG" mapto="last" flags="m" />
+		<key id="KEY_PAGEDOWN" mapto="pageDown" flags="mr" />
+		<key id="KEY_END" mapto="bottom" flags="m" />
+	</map>
+
+	<map context="NumberActions">
+		<key id="KEY_0" mapto="0" flags="m" />
+		<key id="KEY_1" mapto="1" flags="m" />
+		<key id="KEY_2" mapto="2" flags="m" />
+		<key id="KEY_3" mapto="3" flags="m" />
+		<key id="KEY_4" mapto="4" flags="m" />
+		<key id="KEY_5" mapto="5" flags="m" />
+		<key id="KEY_6" mapto="6" flags="m" />
+		<key id="KEY_7" mapto="7" flags="m" />
+		<key id="KEY_8" mapto="8" flags="m" />
+		<key id="KEY_9" mapto="9" flags="m" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_KP0" mapto="0" flags="m" />
+		<key id="KEY_KP1" mapto="1" flags="m" />
+		<key id="KEY_KP2" mapto="2" flags="m" />
+		<key id="KEY_KP3" mapto="3" flags="m" />
+		<key id="KEY_KP4" mapto="4" flags="m" />
+		<key id="KEY_KP5" mapto="5" flags="m" />
+		<key id="KEY_KP6" mapto="6" flags="m" />
+		<key id="KEY_KP7" mapto="7" flags="m" />
+		<key id="KEY_KP8" mapto="8" flags="m" />
+		<key id="KEY_KP9" mapto="9" flags="m" />
+	</map>
+
+	<map context="TextEditActions">
+		<key id="KEY_LAST" mapto="backspace" flags="mr" />
+		<key id="KEY_STOP" mapto="backspace" flags="mr" />
+		<key id="KEY_PLAYPAUSE" mapto="delete" flags="mr" />
+		<key id="KEY_PLAY" mapto="delete" flags="mr" />
+		<key id="KEY_PAUSE" mapto="delete" flags="mr" />
+		<key id="KEY_FILE" mapto="erase" flags="m" />
+		<key id="KEY_LIST" mapto="erase" flags="m" />
+		<key id="KEY_MEDIA" mapto="erase" flags="m" />
+		<key id="KEY_PVR" mapto="erase" flags="m" />
+		<key id="KEY_VIDEO" mapto="erase" flags="m" />
+		<key id="KEY_INFO" mapto="toggleOverwrite" flags="m" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_BACKSPACE" mapto="backspace" flags="mr" />
+		<key id="KEY_DELETE" mapto="delete" flags="mr" />
+		<KEY id="KEY_F5" mapto="erase" flags="m" />
+		<key id="KEY_INSERT" mapto="toggleInsert" flags="m" />
+		<key id="KEY_ASCII" mapto="gotAsciiCode" flags="mr" />
+	</map>
+
+	<map context="VirtualKeyboardActions">
+		<key id="KEY_TEXT" mapto="showVirtualKeyboard" flags="m" />
+	</map>
+
+	<!--
+		These should be module specific key maps.
+	-->
+
+	<map context="ConfigListActions">
+		<!-- Also uses NavigationActions -->
+		<!-- Also uses NumberActions -->
+		<!-- Also uses TextEditActions -->
+		<key id="KEY_RED" mapto="cancel" flags="m" />
+		<key id="KEY_GREEN" mapto="save" flags="m" />
+		<key id="KEY_EXIT" mapto="cancel" flags="b" />
+		<key id="KEY_EXIT" mapto="close" flags="l" />
+		<key id="KEY_OK" mapto="select" flags="m" />
+		<key id="KEY_MENU" mapto="menu" flags="m" />
+		<key id="KEY_FILE" mapto="menu" flags="m" />
+		<key id="KEY_LIST" mapto="menu" flags="m" />
+		<key id="KEY_MEDIA" mapto="menu" flags="m" />
+		<key id="KEY_PVR" mapto="menu" flags="m" />
+		<key id="KEY_VIDEO" mapto="menu" flags="m" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_F1" mapto="cancel" flags="m" />
+		<key id="KEY_F2" mapto="save" flags="m" />
+		<key id="KEY_ESC" mapto="cancel" flags="b" />
+		<key id="KEY_ESC" mapto="close" flags="l" />
+		<key id="KEY_ENTER" mapto="select" flags="m" />
+		<key id="KEY_TAB" mapto="menu" flags="m" />
+	</map>
+
+	<map context="LanguageSelectionActions">
+		<key id="KEY_RED" mapto="cancel" flags="m" />
+		<key id="KEY_GREEN" mapto="save" flags="m" />
+		<key id="KEY_YELLOW" mapto="manage" flags="m" />
+		<key id="KEY_EXIT" mapto="cancel" flags="b" />
+		<key id="KEY_EXIT" mapto="close" flags="l" />
+		<key id="KEY_OK" mapto="select" flags="m" />
+		<key id="KEY_MENU" mapto="menu" flags="m"/>
+	</map>
+
+	<map context="LocationBoxActions">
+		<!-- Also uses NavigationActions -->
+		<!-- Also uses NumberActions -->
+		<key id="KEY_RED" mapto="cancel" flags="m" />
+		<key id="KEY_GREEN" mapto="select" flags="m" />
+		<key id="KEY_YELLOW" mapto="bookmark" flags="m" />
+		<key id="KEY_BLUE" mapto="rename" flags="m" />
+		<key id="KEY_EXIT" mapto="cancel" flags="m" />
+		<key id="KEY_MENU" mapto="menu" flags="m" />
+		<key id="KEY_OK" mapto="enter" flags="mr" />
+		<key id="KEY_FILE" mapto="swap" flags="m" />
+		<key id="KEY_LIST" mapto="swap" flags="m" />
+		<key id="KEY_MEDIA" mapto="swap" flags="m" />
+		<key id="KEY_PVR" mapto="swap" flags="m" />
+		<key id="KEY_VIDEO" mapto="swap" flags="m" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_F1" mapto="cancel" flags="m" />
+		<key id="KEY_F2" mapto="select" flags="m" />
+		<key id="KEY_F3" mapto="bookmark" flags="m" />
+		<key id="KEY_F4" mapto="rename" flags="m" />
+		<key id="KEY_ESC" mapto="cancel" flags="m" />
+		<key id="KEY_ENTER" mapto="select" flags="mr" />
+		<key id="KEY_PREVIOUSSONG" mapto="first" flags="m" />
+		<key id="KEY_F9" mapto="first" flags="m" />
+		<key id="KEY_F11" mapto="prev" flags="m" />
+		<key id="KEY_F12" mapto="next" flags="m" />
+		<key id="KEY_NEXTSONG" mapto="last" flags="m" />
+		<key id="KEY_F10" mapto="last" flags="m" />
+		<key id="KEY_ASCII" mapto="gotAsciiCode" flags="mr" />
+	</map>
+
+	<map context="VirtualKeyBoardActions">
+		<!-- Also uses NumberActions - NOT YET!!! -->
+		<!-- Also uses TextEditActions - NOT YET!!! -->
+		<key id="KEY_RED" mapto="cancel" flags="m" />
+		<key id="KEY_GREEN" mapto="save" flags="m" />
+		<key id="KEY_YELLOW" mapto="shift" flags="m" />
+		<key id="KEY_BLUE" mapto="capsLock" flags="m" />
+		<key id="KEY_EXIT" mapto="cancel" flags="m" />
+		<key id="KEY_OK" mapto="select" flags="mr" />
+		<key id="KEY_TEXT" mapto="locale" flags="m" />
+		<key id="KEY_UP" mapto="up" flags="mr" />
+		<key id="KEY_PREVIOUS" mapto="first" flags="m" />
+		<key id="KEY_REWIND" mapto="prev" flags="mr" />
+		<key id="KEY_LEFT" mapto="left" flags="mr" />
+		<key id="KEY_RIGHT" mapto="right" flags="mr" />
+		<key id="KEY_FASTFORWARD" mapto="next" flags="mr" />
+		<key id="KEY_NEXT" mapto="last" flags="m" />
+		<key id="KEY_DOWN" mapto="down" flags="mr" />
+		<key id="KEY_LAST" mapto="backspace" flags="mr" />
+		<key id="KEY_STOP" mapto="backspace" flags="mr" />
+		<key id="KEY_PLAYPAUSE" mapto="delete" flags="mr" />
+		<key id="KEY_PLAY" mapto="delete" flags="mr" />
+		<key id="KEY_PAUSE" mapto="delete" flags="mr" />
+		<key id="KEY_FILE" mapto="erase" flags="m" />
+		<key id="KEY_LIST" mapto="erase" flags="m" />
+		<key id="KEY_MEDIA" mapto="erase" flags="m" />
+		<key id="KEY_PVR" mapto="erase" flags="m" />
+		<key id="KEY_VIDEO" mapto="erase" flags="m" />
+		<key id="KEY_INFO" mapto="toggleOverwrite" flags="m" />
+		<key id="KEY_0" mapto="0" flags="m" />
+		<key id="KEY_1" mapto="1" flags="m" />
+		<key id="KEY_2" mapto="2" flags="m" />
+		<key id="KEY_3" mapto="3" flags="m" />
+		<key id="KEY_4" mapto="4" flags="m" />
+		<key id="KEY_5" mapto="5" flags="m" />
+		<key id="KEY_6" mapto="6" flags="m" />
+		<key id="KEY_7" mapto="7" flags="m" />
+		<key id="KEY_8" mapto="8" flags="m" />
+		<key id="KEY_9" mapto="9" flags="m" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_F1" mapto="cancel" flags="m" />
+		<key id="KEY_F2" mapto="save" flags="m" />
+		<key id="KEY_F3" mapto="locale" flags="m" />
+		<key id="KEY_F4" mapto="shift" flags="m" />
+		<key id="KEY_ESC" mapto="cancel" flags="m" />
+		<key id="KEY_ENTER" mapto="select" flags="mr" />
+		<key id="KEY_PREVIOUSSONG" mapto="first" flags="m" />
+		<key id="KEY_F9" mapto="first" flags="m" />
+		<key id="KEY_F11" mapto="prev" flags="m" />
+		<key id="KEY_F12" mapto="next" flags="m" />
+		<key id="KEY_NEXTSONG" mapto="last" flags="m" />
+		<key id="KEY_F10" mapto="last" flags="m" />
+		<key id="KEY_BACKSPACE" mapto="backspace" flags="mr" />
+		<key id="KEY_DELETE" mapto="delete" flags="mr" />
+		<KEY id="KEY_F5" mapto="erase" flags="m" />
+		<key id="KEY_INSERT" mapto="toggleInsert" flags="m" />
+		<key id="KEY_ASCII" mapto="gotAsciiCode" flags="mr" />
+		<key id="KEY_KP0" mapto="0" flags="m" />
+		<key id="KEY_KP1" mapto="1" flags="m" />
+		<key id="KEY_KP2" mapto="2" flags="m" />
+		<key id="KEY_KP3" mapto="3" flags="m" />
+		<key id="KEY_KP4" mapto="4" flags="m" />
+		<key id="KEY_KP5" mapto="5" flags="m" />
+		<key id="KEY_KP6" mapto="6" flags="m" />
+		<key id="KEY_KP7" mapto="7" flags="m" />
+		<key id="KEY_KP8" mapto="8" flags="m" />
+		<key id="KEY_KP9" mapto="9" flags="m" />
+	</map>
+
+	<!--
+		These key maps are yet to be checked / updated.
+	-->
+
 	<map context="ListboxActions">
 		<device name="keyboard">
 			<key id="a" mapto="up" flags="mr"/>
@@ -23,6 +266,28 @@
 
 		<key id="1" mapto="moveUp" flags="mr"/>
 		<key id="2" mapto="moveDown" flags="mr"/>
+	</map>
+
+	<!--+
+	    | Map to catch break events for the ListboxActions keys
+	    | in Screens.HelpMenu so that those are not passed through
+	    | to the HelpMenu wildcard actions as unhandled keypresses.
+	    +-->
+	<map context="ListboxHelpMenuActions">
+		<device name="keyboard">
+			<key id="a" mapto="ignore" flags="b" />
+			<key id="b" mapto="ignore" flags="b" />
+		</device>
+		<key id="KEY_UP" mapto="ignore" flags="b" />
+		<key id="KEY_DOWN" mapto="ignore" flags="b" />
+		<key id="KEY_HOME" mapto="ignore" flags="b" />
+		<key id="KEY_END" mapto="ignore" flags="b" />
+		<key id="KEY_PAGEUP" mapto="ignore" flags="b" />
+		<key id="KEY_PAGEDOWN" mapto="ignore" flags="b" />
+		<key id="KEY_LEFT" mapto="ignore" flags="b" />
+		<key id="KEY_RIGHT" mapto="ignore" flags="b" />
+		<key id="1" mapto="ignore" flags="b" />
+		<key id="2" mapto="ignore" flags="b" />
 	</map>
 
 	<map context="KeyboardInputActions">
@@ -69,137 +334,6 @@
 		<key id="KEY_FILE" mapto="file" flags="m"/>
 		<key id="KEY_MEDIA" mapto="file" flags="m"/>
 		<key id="KEY_VIDEO" mapto="file" flags="m"/>
-	</map>
-
-	<map context="ConfigListActions">
-		<key id="KEY_RED" mapto="cancel" flags="m" />
-		<key id="KEY_GREEN" mapto="save" flags="m" />
-		<key id="KEY_EXIT" mapto="cancel" flags="b" />
-		<key id="KEY_EXIT" mapto="close" flags="l" />
-		<key id="KEY_MENU" mapto="menu" flags="m" />
-		<key id="KEY_FILE" mapto="menu" flags="m" />
-		<key id="KEY_MEDIA" mapto="menu" flags="m" />
-		<key id="KEY_VIDEO" mapto="menu" flags="m" />
-		<key id="KEY_OK" mapto="select" flags="m" />
-		<key id="KEY_REWIND" mapto="top" flags="m" />
-		<key id="KEY_CHANNELUP" mapto="pageUp" flags="mr" />
-		<key id="KEY_UP" mapto="up" flags="mr" />
-		<key id="KEY_PREVIOUS" mapto="first" flags="m" />
-		<key id="KEY_LEFT" mapto="left" flags="mr" />
-		<key id="KEY_RIGHT" mapto="right" flags="mr" />
-		<key id="KEY_NEXT" mapto="last" flags="m" />
-		<key id="KEY_DOWN" mapto="down" flags="mr" />
-		<key id="KEY_CHANNELDOWN" mapto="pageDown" flags="mr" />
-		<key id="KEY_FASTFORWARD" mapto="bottom" flags="m" />
-		<key id="KEY_LAST" mapto="backspace" flags="mr" />
-		<key id="KEY_STOP" mapto="backspace" flags="mr" />
-		<key id="KEY_PLAYPAUSE" mapto="delete" flags="mr" />
-		<key id="KEY_PLAY" mapto="delete" flags="mr" />
-		<key id="KEY_INFO" mapto="toggleOverwrite" flags="m" />
-		<key id="KEY_0" mapto="0" flags="m" />
-		<key id="KEY_1" mapto="1" flags="m" />
-		<key id="KEY_2" mapto="2" flags="m" />
-		<key id="KEY_3" mapto="3" flags="m" />
-		<key id="KEY_4" mapto="4" flags="m" />
-		<key id="KEY_5" mapto="5" flags="m" />
-		<key id="KEY_6" mapto="6" flags="m" />
-		<key id="KEY_7" mapto="7" flags="m" />
-		<key id="KEY_8" mapto="8" flags="m" />
-		<key id="KEY_9" mapto="9" flags="m" />
-		<!-- Keyboard specific buttons -->
-		<key id="KEY_F1" mapto="cancel" flags="m" />
-		<key id="KEY_F2" mapto="save" flags="m" />
-		<key id="KEY_ESC" mapto="cancel" flags="b" />
-		<key id="KEY_ESC" mapto="close" flags="l" />
-		<key id="KEY_ENTER" mapto="select" flags="m" />
-		<key id="KEY_TAB" mapto="menu" flags="m" />
-		<key id="KEY_F5" mapto="menu" flags="m" />
-		<key id="KEY_HOME" mapto="top" flags="m" />
-		<key id="KEY_PAGEUP" mapto="pageUp" flags="m" />
-		<key id="KEY_PREVIOUSSONG" mapto="first" flags="m" />
-		<key id="KEY_F9" mapto="first" flags="m" />
-		<key id="KEY_PAGEDOWN" mapto="pageDown" flags="m" />
-		<key id="KEY_END" mapto="bottom" flags="m" />
-		<key id="KEY_NEXTSONG" mapto="last" flags="m" />
-		<key id="KEY_F10" mapto="last" flags="m" />
-		<key id="KEY_BACKSPACE" mapto="backspace" flags="mr" />
-		<key id="KEY_DELETE" mapto="delete" flags="mr" />
-		<key id="KEY_INSERT" mapto="toggleInsert" flags="m" />
-		<key id="KEY_ASCII" mapto="gotAsciiCode" flags="mr" />
-		<key id="KEY_KP0" mapto="0" flags="m" />
-		<key id="KEY_KP1" mapto="1" flags="m" />
-		<key id="KEY_KP2" mapto="2" flags="m" />
-		<key id="KEY_KP3" mapto="3" flags="m" />
-		<key id="KEY_KP4" mapto="4" flags="m" />
-		<key id="KEY_KP5" mapto="5" flags="m" />
-		<key id="KEY_KP6" mapto="6" flags="m" />
-		<key id="KEY_KP7" mapto="7" flags="m" />
-		<key id="KEY_KP8" mapto="8" flags="m" />
-		<key id="KEY_KP9" mapto="9" flags="m" />
-	</map>
-
-	<map context="VirtualKeyBoardActions">
-		<key id="KEY_RED" mapto="cancel" flags="m" />
-		<key id="KEY_GREEN" mapto="save" flags="m" />
-		<key id="KEY_YELLOW" mapto="shift" flags="m" />
-		<key id="KEY_BLUE" mapto="capsLock" flags="m" />
-		<key id="KEY_EXIT" mapto="cancel" flags="m" />
-		<key id="KEY_OK" mapto="select" flags="mr" />
-		<key id="KEY_TEXT" mapto="locale" flags="m" />
-		<key id="KEY_UP" mapto="up" flags="mr" />
-		<key id="KEY_PREVIOUS" mapto="first" flags="m" />
-		<key id="KEY_REWIND" mapto="prev" flags="mr" />
-		<key id="KEY_LEFT" mapto="left" flags="mr" />
-		<key id="KEY_RIGHT" mapto="right" flags="mr" />
-		<key id="KEY_FASTFORWARD" mapto="next" flags="mr" />
-		<key id="KEY_NEXT" mapto="last" flags="m" />
-		<key id="KEY_DOWN" mapto="down" flags="mr" />
-		<key id="KEY_LAST" mapto="backspace" flags="mr" />
-		<key id="KEY_STOP" mapto="backspace" flags="mr" />
-		<key id="KEY_PLAYPAUSE" mapto="delete" flags="mr" />
-		<key id="KEY_PLAY" mapto="delete" flags="mr" />
-		<key id="KEY_VIDEO" mapto="erase" flags="m" />
-		<key id="KEY_MEDIA" mapto="erase" flags="m" />
-		<key id="KEY_LIST" mapto="erase" flags="m" />
-		<key id="KEY_PVR" mapto="erase" flags="m" />
-		<key id="KEY_INFO" mapto="toggleOverwrite" flags="m" />
-		<key id="KEY_0" mapto="0" flags="m" />
-		<key id="KEY_1" mapto="1" flags="m" />
-		<key id="KEY_2" mapto="2" flags="m" />
-		<key id="KEY_3" mapto="3" flags="m" />
-		<key id="KEY_4" mapto="4" flags="m" />
-		<key id="KEY_5" mapto="5" flags="m" />
-		<key id="KEY_6" mapto="6" flags="m" />
-		<key id="KEY_7" mapto="7" flags="m" />
-		<key id="KEY_8" mapto="8" flags="m" />
-		<key id="KEY_9" mapto="9" flags="m" />
-		<!-- Keyboard specific buttons -->
-		<key id="KEY_F1" mapto="cancel" flags="m" />
-		<key id="KEY_F2" mapto="save" flags="m" />
-		<key id="KEY_F3" mapto="locale" flags="m" />
-		<key id="KEY_F4" mapto="shift" flags="m" />
-		<key id="KEY_ESC" mapto="cancel" flags="m" />
-		<key id="KEY_ENTER" mapto="select" flags="mr" />
-		<key id="KEY_PREVIOUSSONG" mapto="first" flags="m" />
-		<key id="KEY_F9" mapto="first" flags="m" />
-		<key id="KEY_F11" mapto="prev" flags="m" />
-		<key id="KEY_F12" mapto="next" flags="m" />
-		<key id="KEY_NEXTSONG" mapto="last" flags="m" />
-		<key id="KEY_F10" mapto="last" flags="m" />
-		<key id="KEY_BACKSPACE" mapto="backspace" flags="mr" />
-		<key id="KEY_DELETE" mapto="delete" flags="mr" />
-		<key id="KEY_INSERT" mapto="toggleOverwrite" flags="m" />
-		<key id="KEY_ASCII" mapto="gotAsciiCode" flags="mr" />
-		<key id="KEY_KP0" mapto="0" flags="m" />
-		<key id="KEY_KP1" mapto="1" flags="m" />
-		<key id="KEY_KP2" mapto="2" flags="m" />
-		<key id="KEY_KP3" mapto="3" flags="m" />
-		<key id="KEY_KP4" mapto="4" flags="m" />
-		<key id="KEY_KP5" mapto="5" flags="m" />
-		<key id="KEY_KP6" mapto="6" flags="m" />
-		<key id="KEY_KP7" mapto="7" flags="m" />
-		<key id="KEY_KP8" mapto="8" flags="m" />
-		<key id="KEY_KP9" mapto="9" flags="m" />
 	</map>
 
 	<map context="InputActions">
@@ -430,35 +564,9 @@
 		<key id="KEY_TV" mapto="exit" flags="m"/>
 	</map>
 
-	<map context="GlobalActions">
-		<key id="KEY_VOLUMEUP" mapto="volumeUp" flags="mr"/>
-		<key id="KEY_VOLUMEDOWN" mapto="volumeDown" flags="mr"/>
-		<key id="KEY_MUTE" mapto="volumeMute" flags="mr"/>
-		<key id="KEY_POWER" mapto="power_long" flags="l"/>
-		<key id="KEY_POWER" mapto="power_down" flags="m"/>
-		<key id="KEY_POWER" mapto="power_up" flags="b"/>
-		<key id="KEY_KP0" mapto="discrete_off" flags="m"/>
-		<device name="dreambox front panel">
-			<key id="KEY_POWER" mapto="deepstandby" flags="l"/>
-		</device>
-	</map>
-
 	<map context="PowerKeyActions">
 		<key id="KEY_POWER" mapto="powerdown" flags="m"/>
 		<key id="KEY_POWER" mapto="powerup" flags="b"/>
-	</map>
-
-	<map context="NumberActions">
-		<key id="KEY_1" mapto="1" flags="m"/>
-		<key id="KEY_2" mapto="2" flags="m"/>
-		<key id="KEY_3" mapto="3" flags="m"/>
-		<key id="KEY_4" mapto="4" flags="m"/>
-		<key id="KEY_5" mapto="5" flags="m"/>
-		<key id="KEY_6" mapto="6" flags="m"/>
-		<key id="KEY_7" mapto="7" flags="m"/>
-		<key id="KEY_8" mapto="8" flags="m"/>
-		<key id="KEY_9" mapto="9" flags="m"/>
-		<key id="KEY_0" mapto="0" flags="m"/>
 	</map>
 
 	<map context="TextEntryActions">
@@ -689,10 +797,6 @@
 		<key id="KEY_0" mapto="toggleMark" flags="m"/>
 	</map>
 
-	<map context="VirtualKeyboardActions">
-		<key id="KEY_TEXT" mapto="showVirtualKeyboard" flags="m"/>
-	</map>
-
 	<map context="InfobarTeletextActions">
 		<key id="KEY_TEXT" mapto="startTeletext" flags="m"/>
 	</map>
@@ -864,10 +968,6 @@
 	</map>
 
 	<map context="WindowActions">
-	</map>
-
-	<map context="HelpActions">
-		<key id="KEY_HELP" mapto="displayHelp" flags="b"/>
 	</map>
 
 	<map context="ShortcutActions">

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -2,7 +2,7 @@ from enigma import eListbox, eListboxPythonConfigContent, ePoint, eRCInput, eTim
 from skin import parameters
 
 from Components.ActionMap import HelpableActionMap, HelpableNumberActionMap
-from Components.config import ConfigBoolean, ConfigElement, ConfigInteger, ConfigMacText, ConfigSelection, ConfigSequence, ConfigText, KEYA_LEFT, KEYA_RIGHT, KEYA_HOME, KEYA_END, KEYA_0, KEYA_DELETE, KEYA_BACKSPACE, KEYA_SELECT, KEYA_TOGGLEOW, KEYA_ASCII, KEYA_NUMBERS, KEYA_TIMEOUT, config, configfile
+from Components.config import ConfigBoolean, ConfigElement, ConfigInteger, ConfigMacText, ConfigSelection, ConfigSequence, ConfigText, KEYA_0, KEYA_ASCII, KEYA_BACKSPACE, KEYA_DELETE, KEYA_END, KEYA_ERASE, KEYA_HOME, KEYA_LEFT, KEYA_NUMBERS, KEYA_RIGHT, KEYA_SELECT, KEYA_TIMEOUT, KEYA_TOGGLEOW, config, configfile
 from Components.GUIComponent import GUIComponent
 from Components.Pixmap import Pixmap
 from Components.Sources.Boolean import Boolean
@@ -157,7 +157,7 @@ class ConfigListScreen:
 			self["HelpWindow"].hide()
 		if "VKeyIcon" not in self:
 			self["VKeyIcon"] = Boolean(False)
-		self["configActions"] = HelpableNumberActionMap(self, "ConfigListActions", {
+		self["configActions"] = HelpableNumberActionMap(self, ["ConfigListActions", "NavigationActions"], {
 			"cancel": (self.keyCancel, _("Cancel any changed settings and exit")),
 			"close": (self.closeRecursive, _("Cancel any changed settings and exit all menus")),
 			"save": (self.keySave, _("Save all changed settings and exit")),
@@ -177,10 +177,11 @@ class ConfigListScreen:
 			"menu": (self.keyMenu, _("Display selection list as a selection menu")),
 		}, prio=-1, description=_("Common Setup Functions"))
 		self["menuConfigActions"].setEnabled(False)
-		self["digitConfigActions"] = HelpableNumberActionMap(self, "ConfigListActions", {
-			"toggleOverwrite": (self.keyToggleOW, _("Toggle new text inserts before or overwrites existing text")),
+		self["editConfigActions"] = HelpableNumberActionMap(self, ["NumberActions", "TextEditActions"], {
 			"backspace": (self.keyBackspace, _("Delete the character to the left of cursor")),
 			"delete": (self.keyDelete, _("Delete the character under the cursor")),
+			"erase": (self.keyErase, _("Delete all the text")),
+			"toggleOverwrite": (self.keyToggleOW, _("Toggle new text inserts before or overwrites existing text")),
 			"1": (self.keyNumberGlobal, _("Number or SMS style data entry")),
 			"2": (self.keyNumberGlobal, _("Number or SMS style data entry")),
 			"3": (self.keyNumberGlobal, _("Number or SMS style data entry")),
@@ -193,7 +194,7 @@ class ConfigListScreen:
 			"0": (self.keyNumberGlobal, _("Number or SMS style data entry")),
 			"gotAsciiCode": (self.keyGotAscii, _("Keyboard data entry"))
 		}, prio=-1, description=_("Common Setup Functions"))
-		self["digitConfigActions"].setEnabled(False)
+		self["editConfigActions"].setEnabled(False)
 		self["VirtualKB"] = HelpableActionMap(self, "VirtualKeyboardActions", {
 			"showVirtualKeyboard": (self.keyText, _("Display the virtual keyboard for data entry"))
 		}, prio=-2, description=_("Common Setup Functions"))
@@ -239,9 +240,9 @@ class ConfigListScreen:
 		currConfig = self["config"].getCurrent()
 		if currConfig is not None:
 			if isinstance(currConfig[1], (ConfigInteger, ConfigMacText, ConfigSequence, ConfigText)):
-				self["digitConfigActions"].setEnabled(True)
+				self["editConfigActions"].setEnabled(True)
 			else:
-				self["digitConfigActions"].setEnabled(False)
+				self["editConfigActions"].setEnabled(False)
 			if isinstance(currConfig[1], ConfigSelection):
 				self["menuConfigActions"].setEnabled(True)
 				self["key_menu"].setText(_("MENU"))
@@ -312,12 +313,17 @@ class ConfigListScreen:
 			self["config"].invalidateCurrent()
 			self.entryChanged()
 
+	def keyTop(self):
+		self["config"].moveTop()
+
+	def keyPageUp(self):
+		self["config"].pageUp()
+
+	def keyUp(self):
+		self["config"].moveUp()
+
 	def keyFirst(self):
 		self["config"].handleKey(KEYA_HOME)
-		self.entryChanged()
-
-	def keyLast(self):
-		self["config"].handleKey(KEYA_END)
 		self.entryChanged()
 
 	def keyLeft(self):
@@ -328,20 +334,29 @@ class ConfigListScreen:
 		self["config"].handleKey(KEYA_RIGHT)
 		self.entryChanged()
 
-	def keyHome(self):
-		self["config"].handleKey(KEYA_HOME)
+	def keyLast(self):
+		self["config"].handleKey(KEYA_END)
 		self.entryChanged()
 
-	def keyEnd(self):
-		self["config"].handleKey(KEYA_END)
+	def keyDown(self):
+		self["config"].moveDown()
+
+	def keyPageDown(self):
+		self["config"].pageDown()
+
+	def keyBottom(self):
+		self["config"].moveBottom()
+
+	def keyBackspace(self):
+		self["config"].handleKey(KEYA_BACKSPACE)
 		self.entryChanged()
 
 	def keyDelete(self):
 		self["config"].handleKey(KEYA_DELETE)
 		self.entryChanged()
 
-	def keyBackspace(self):
-		self["config"].handleKey(KEYA_BACKSPACE)
+	def keyErase(self):
+		self["config"].handleKey(KEYA_DELETE)
 		self.entryChanged()
 
 	def keyToggleOW(self):
@@ -355,24 +370,6 @@ class ConfigListScreen:
 	def keyNumberGlobal(self, number):
 		self["config"].handleKey(KEYA_0 + number)
 		self.entryChanged()
-
-	def keyTop(self):
-		self["config"].moveTop()
-
-	def keyBottom(self):
-		self["config"].moveBottom()
-
-	def keyPageUp(self):
-		self["config"].pageUp()
-
-	def keyPageDown(self):
-		self["config"].pageDown()
-
-	def keyUp(self):
-		self["config"].moveUp()
-
-	def keyDown(self):
-		self["config"].moveDown()
 
 	def keySave(self):
 		self.saveAll()

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -32,6 +32,7 @@ KEYA_PAGEUP = 22
 KEYA_PAGEDOWN = 23
 KEYA_PREV = 24
 KEYA_NEXT = 25
+KEYA_ERASE = 26
 
 # Deprecated / Legacy action key names...
 #
@@ -1132,12 +1133,12 @@ class ConfigFloat(ConfigSequence):
 
 	floatint = property(getFloatInt, setFloatInt)
 
-# an editable text...
+# An editable text item.
+#
 class ConfigText(ConfigElement, NumericalTextInput):
 	def __init__(self, default="", fixed_size=True, visible_width=False):
 		ConfigElement.__init__(self)
 		NumericalTextInput.__init__(self, nextFunc=self.nextFunc, handleTimeout=False)
-
 		self.marked_pos = 0
 		self.allmarked = (default != "")
 		self.fixed_size = fixed_size
@@ -1192,27 +1193,12 @@ class ConfigText(ConfigElement, NumericalTextInput):
 		self.marked_pos = 0
 
 	def handleKey(self, key):
-		# this will no change anything on the value itself
-		# so we can handle it here in gui element
-		if key == KEY_DELETE:
+		# This will no change anything on the value itself
+		# so we can handle it here in gui element.
+		if key == KEY_HOME:
 			self.timeout()
-			if self.allmarked:
-				self.deleteAllChars()
-				self.allmarked = False
-			else:
-				self.deleteChar(self.marked_pos)
-				if self.fixed_size and self.overwrite:
-					self.marked_pos += 1
-		elif key == KEY_BACKSPACE:
-			self.timeout()
-			if self.allmarked:
-				self.deleteAllChars()
-				self.allmarked = False
-			elif self.marked_pos > 0:
-				self.deleteChar(self.marked_pos - 1)
-				if not self.fixed_size and self.offset > 0:
-					self.offset -= 1
-				self.marked_pos -= 1
+			self.allmarked = False
+			self.marked_pos = 0
 		elif key == KEY_LEFT:
 			self.timeout()
 			if self.allmarked:
@@ -1227,14 +1213,32 @@ class ConfigText(ConfigElement, NumericalTextInput):
 				self.allmarked = False
 			else:
 				self.marked_pos += 1
-		elif key == KEY_HOME:
-			self.timeout()
-			self.allmarked = False
-			self.marked_pos = 0
 		elif key == KEY_END:
 			self.timeout()
 			self.allmarked = False
 			self.marked_pos = len(self.text)
+		elif key == KEY_BACKSPACE:
+			self.timeout()
+			if self.allmarked:
+				self.deleteAllChars()
+				self.allmarked = False
+			elif self.marked_pos > 0:
+				self.deleteChar(self.marked_pos - 1)
+				if not self.fixed_size and self.offset > 0:
+					self.offset -= 1
+				self.marked_pos -= 1
+		elif key == KEY_DELETE:
+			self.timeout()
+			if self.allmarked:
+				self.deleteAllChars()
+				self.allmarked = False
+			else:
+				self.deleteChar(self.marked_pos)
+				if self.fixed_size and self.overwrite:
+					self.marked_pos += 1
+		elif key == KEY_ERASE:
+			self.timeout()
+			self.deleteAllChars()
 		elif key == KEY_TOGGLEOW:
 			self.timeout()
 			self.overwrite = not self.overwrite
@@ -1335,6 +1339,7 @@ class ConfigText(ConfigElement, NumericalTextInput):
 
 	def unsafeAssign(self, value):
 		self.value = str(value)
+
 
 class ConfigPassword(ConfigText):
 	def __init__(self, default="", fixed_size=False, visible_width=False, censor="*"):


### PR DESCRIPTION
[keymap.xml] Start organising the keymaps
- Start grouping and documenting the keymaps.
- Add an Erase (Delete all) function to the ConfigListActions keymap.

[ConfigList.py] Add Erase function and clean up
- Add an Erase (Delete all) function to match the VirtualKeyBoard.
- Update the keymap inclusions to reflect optimisations in the keymap file.
- Remove defunct methods and reorganise the methods to match the keymap and action map sequence.

[config.py] Add Erase function and clean up
- Add a new KEYA_ERASE action to allow for the new Erase (Delete all) option.
- Add an Erase (Delete all) function to ConfigText to match the VirtualKeyBoard.
- Reorganise the methods to match the keymap and action map sequence.
