### PR TITLE
[ConfigList.py] Apply some corrections and clean up

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -201,7 +201,6 @@ class ConfigListScreen:
 		self["VirtualKB"].setEnabled(False)
 		self["config"] = ConfigList(list, session=session)
 		self.setCancelMessage(None)
-		self.setRestartMessage(None)
 		self.onChangedEntry = []
 		if self.handleInputHelpers not in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.handleInputHelpers)
@@ -216,9 +215,6 @@ class ConfigListScreen:
 
 	def setCancelMessage(self, msg):
 		self.cancelMsg = _("Really close without saving settings?") if msg is None else msg
-
-	def setRestartMessage(self, msg):
-		self.restartMsg = _("Restart GUI now?") if msg is None else msg
 
 	def getCurrentItem(self):
 		return self["config"].getCurrent() and self["config"].getCurrent()[1] or None
@@ -383,10 +379,6 @@ class ConfigListScreen:
 			x[1].save()
 		configfile.save()
 		if restart:
-			self.session.openWithCallback(self.restartConfirm, MessageBox, self.restartMsg, default=True, type=MessageBox.TYPE_YESNO)
-
-	def restartConfirm(self, result):
-		if result:
 			self.session.open(TryQuitMainloop, retvalue=QUIT_RESTART)
 
 	def keyCancel(self):

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -122,17 +122,9 @@ class ConfigList(GUIComponent, object):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.moveTop)
 
-	def moveBottom(self):
-		if self.instance is not None:
-			self.instance.moveSelection(self.instance.moveEnd)
-
 	def pageUp(self):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.pageUp)
-
-	def pageDown(self):
-		if self.instance is not None:
-			self.instance.moveSelection(self.instance.pageDown)
 
 	def moveUp(self):
 		if self.instance is not None:
@@ -141,6 +133,14 @@ class ConfigList(GUIComponent, object):
 	def moveDown(self):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.moveDown)
+
+	def pageDown(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.pageDown)
+
+	def moveBottom(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveEnd)
 
 
 class ConfigListScreen:

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -265,7 +265,7 @@ class ConfigListScreen:
 		self.displayHelp(False)
 
 	def displayHelp(self, state):
-		if "config" in self and "HelpWindow" in self and self["config"].getCurrent() is not None:
+		if "config" in self and "HelpWindow" in self and self["config"].getCurrent() is not None and len(self["config"].getCurrent()) > 1:
 			currConf = self["config"].getCurrent()[1]
 			if isinstance(currConf, ConfigText) and currConf.help_window is not None and currConf.help_window.instance is not None:
 				if state:


### PR DESCRIPTION
[ConfigList.py] Reorder methods
- Reorder the movement methods to match the keymap and action map sequence.

[ConfigList.py] Remove restart confirmation
- Remove the code to support the restart confirmation that is no longer used.

    The user already gets a notification in the footer that a restart will be required.  The extra confirmation screen creates a modal screen issue.

[ConfigList.py] Fix crash issue
-  Add protection against uses of ConfigList that are not for config lists. (Some code uses ConfigList to achieve a pretty display but are not actually used for configuration. This sort of code should no longer crash ConfigList.)

    One example that caused this issue was Screens/AutoDiseqc.py
