### PR TITLE
[driver] Allow low-level key remapping from Python

### DIFF
--- a/lib/driver/rc.cpp
+++ b/lib/driver/rc.cpp
@@ -46,6 +46,11 @@ eRCDevice::~eRCDevice()
 	eRCInput::getInstance()->removeDevice(id.c_str());
 }
 
+int eRCDevice::setKeyMapping(const std::unordered_map<unsigned int, unsigned int>& remaps)
+{
+	return eRCInput::remapUnsupported;
+}
+
 eRCDriver::eRCDriver(eRCInput *input): input(input), enabled(1)
 {
 }
@@ -252,6 +257,26 @@ void eRCInput::addDevice(const std::string &id, eRCDevice *dev)
 void eRCInput::removeDevice(const std::string &id)
 {
 	devices.erase(id);
+}
+
+int eRCInput::setKeyMapping(const std::string &id, ePyObject keyRemap)
+{
+	eRCDevice *dev = getDevice(id);
+	if (dev)
+	{
+		std::unordered_map<unsigned int, unsigned int> remaps;
+		if (!PyDict_Check(keyRemap))
+			return remapFormatErr;
+		PyObject *from, *to;
+		Py_ssize_t pos=0;
+		while (PyDict_Next(keyRemap, &pos, &from, &to)) {
+			if (!PyInt_Check(from) || !PyInt_Check(to))
+				return remapFormatErr;
+			remaps[PyInt_AsLong(from)] = PyInt_AsLong(to);
+		}
+		return dev->setKeyMapping(remaps);
+	}
+	return remapNoSuchDevice;
 }
 
 eRCDevice *eRCInput::getDevice(const std::string &id)

--- a/lib/driver/rc.h
+++ b/lib/driver/rc.h
@@ -9,6 +9,7 @@
 #include <lib/base/ebase.h>
 #include <libsig_comp.h>
 #include <string>
+#include <unordered_map>
 
 class eRCInput;
 class eRCDriver;
@@ -56,6 +57,12 @@ public:
 	 * \result User readable description of given key.
 	 */
 	virtual void setExclusive(bool b) { };
+	/**
+	 * \brief set key remappngs.
+	 * \param remaps The the keyy remappings.
+	 * \result The status indicators defined in eRCInput.
+	 */
+	virtual int setKeyMapping(const std::unordered_map<unsigned int, unsigned int>& remaps);
 };
 
 /**
@@ -244,8 +251,10 @@ public:
 	eRCConfig config;
 #endif
 	enum { kmNone, kmAscii, kmAll };
+	enum { remapOk, remapUnsupported, remapFormatErr, remapNoSuchDevice };
 	void setKeyboardMode(int mode) { keyboardMode = mode; }
 	int  getKeyboardMode() { return keyboardMode; }
+	int setKeyMapping(const std::string &id, SWIG_PYOBJECT(ePyObject) keyRemap);
 	static eRCInput *getInstance() { return instance; }
 	void lock();
 	void unlock();

--- a/lib/driver/rcinput.cpp
+++ b/lib/driver/rcinput.cpp
@@ -90,33 +90,46 @@ void eRCDeviceInputDev::handleCode(long rccode)
 		}
 	}
 
-#if KEY_PLAY_ACTUALLY_IS_KEY_PLAYPAUSE
-	if (ev->code == KEY_PLAY)
+	if (!remaps.empty())
 	{
-		if ((id == "dreambox advanced remote control (native)")  || (id == "bcm7325 remote control"))
+		std::unordered_map<unsigned int, unsigned int>::iterator i = remaps.find(ev->code);
+		if (i != remaps.end())
 		{
-			/* 8k rc has a KEY_PLAYPAUSE key, which sends KEY_PLAY events. Correct this, so we do not have to place hacks in the keymaps. */
-			ev->code = KEY_PLAYPAUSE;
+			eDebug("[eRCDeviceInputDev] map: %u->%u", i->first, i->second);
+			ev->code = i->second;
 		}
 	}
+	else
+	{
+#if KEY_PLAY_ACTUALLY_IS_KEY_PLAYPAUSE
+		if (ev->code == KEY_PLAY)
+		{
+			if ((id == "dreambox advanced remote control (native)")  || (id == "bcm7325 remote control"))
+			{
+				/* 8k rc has a KEY_PLAYPAUSE key, which sends KEY_PLAY events. Correct this, so we do not have to place hacks in the keymaps. */
+				ev->code = KEY_PLAYPAUSE;
+			}
+		}
 #endif
 
 #if KEY_VIDEO_TO_KEY_FAVORITES
-	if (ev->code == KEY_VIDEO)
-	{
-		/* formuler rcu fav key send key_media change this to  KEY_FAVORITES */
-		ev->code = KEY_FAVORITES;
-	}
+		if (ev->code == KEY_VIDEO)
+		{
+			/* formuler rcu fav key send key_media change this to  KEY_FAVORITES */
+			ev->code = KEY_FAVORITES;
+		}
 #endif
 
 #if KEY_BOOKMARKS_TO_KEY_MEDIA
-	if (ev->code == KEY_BOOKMARKS)
-	{
-		/* formuler and triplex remote send wrong keycode */
-		ev->code = KEY_MEDIA;
-	}
+		if (ev->code == KEY_BOOKMARKS)
+		{
+			/* formuler and triplex remote send wrong keycode */
+			ev->code = KEY_MEDIA;
+		}
 #endif
+	}
 
+	eDebug("[eRCDeviceInputDev] emit: %u", ev->value); // ZZ
 	switch (ev->value)
 	{
 		case 0:
@@ -129,6 +142,12 @@ void eRCDeviceInputDev::handleCode(long rccode)
 			input->keyPressed(eRCKey(this, ev->code, eRCKey::flagRepeat)); /*emit*/
 			break;
 	}
+}
+
+int eRCDeviceInputDev::setKeyMapping(const std::unordered_map<unsigned int, unsigned int>& remaps_p)
+{
+	remaps = remaps_p;
+	return eRCInput::remapOk;
 }
 
 eRCDeviceInputDev::eRCDeviceInputDev(eRCInputEventDriver *driver, int consolefd)

--- a/lib/driver/rcinput.h
+++ b/lib/driver/rcinput.h
@@ -8,11 +8,13 @@ class eRCDeviceInputDev: public eRCDevice
 	int iskeyboard, ismouse;
 	int consoleFd;
 	bool shiftState, capsState;
+	std::unordered_map<unsigned int, unsigned int> remaps;
 public:
 	void handleCode(long code);
 	eRCDeviceInputDev(eRCInputEventDriver *driver, int consolefd);
 	const char *getDescription() const;
 	void setExclusive(bool);
+	int setKeyMapping(const std::unordered_map<unsigned int, unsigned int>& remaps);
 };
 
 #endif


### PR DESCRIPTION
The patch of my changes from the Beyonwiz code to ViX went very smoothly, so I'm reasonably confident that the changes should just compile and run in ViX.