### PR TITLE
More Summary changes

### DIFF
--- a/data/display220/skin_display.xml
+++ b/data/display220/skin_display.xml
@@ -16,6 +16,7 @@
 		<color color="#ffffff" name="WindowTitleForeground"/>
 		<color color="#000000" name="WindowTitleBackground"/>
 	</windowstyle>
+
 	<fonts>
 		<!-- pick a funky name for the font, so we don't conflict  -->
 		<font filename="nmsbd.ttf" name="FdLcD" scale="100"/>
@@ -23,7 +24,7 @@
 
 <!-- template -->
 	<screen name="SummaryClockPanel">
-		<widget source="global.CurrentTime" render="Label" position="120,142" size="100,45" font="FdLcD;40" halign="right" valign="bottom" noWrap="1">
+		<widget source="global.CurrentTime" render="Label" position="0,e-40" size="e,40" font="FdLcD;35" halign="right" valign="bottom" noWrap="1">
 			<convert type="ClockToText"/>
 		</widget>
 	</screen>
@@ -47,6 +48,7 @@
 			<convert type="ConditionalShowHide" />
 		</widget>
 	</screen>
+
 	<screen name="SummaryTunerStatusPanel">
 		<widget source="session.TunerInfo" render="Pixmap" pixmap="tuner-a.png" position="0,143" size="19,33">
 			<convert type="TunerInfo">TunerUseMask</convert>
@@ -100,13 +102,13 @@
 		<widget source="parent.Event" render="Progress" position="0,93" size="220,10" borderWidth="1">
 			<convert type="EventTime">Progress</convert>
 		</widget>
-		<widget source="parent.Event" render="Label" position="0,106" size="220,36" font="FdLcD;34" halign="left" valign="bottom" noWrap="1">
+		<widget source="parent.Event" render="Label" position="0,106" size="220,35" font="FdLcD;30" halign="center" valign="bottom" noWrap="1">
 			<convert type="EventTime">VFDRemaining</convert>
 			<convert type="RemainingToText">VFDNoSeconds</convert>
 		</widget>
 	</screen>
 
-<!-- main-->
+<!-- main -->
 	<screen name="InfoBarSummary" position="0,0" size="220,176">
 		<widget source="session.CurrentService" render="Label" position="0,38" size="220,26" font="FdLcD;24" halign="left" noWrap="1" >
 			<convert type="ServiceName">NameOnly</convert>
@@ -117,7 +119,7 @@
 		<widget source="session.Event_Now" render="Progress" position="0,93" size="220,10" borderWidth="1">
 			<convert type="EventTime">Progress</convert>
 		</widget>
-		<widget source="session.Event_Now" render="Label" position="0,106" size="220,36" font="FdLcD;34" halign="left" valign="bottom" noWrap="1">
+		<widget source="session.Event_Now" render="Label" position="0,106" size="220,35" font="FdLcD;30" halign="center" valign="bottom" noWrap="1">
 			<convert type="EventTime">VFDRemaining</convert>
 			<convert type="RemainingToText">VFDNoSeconds</convert>
 		</widget>
@@ -126,27 +128,27 @@
 		<panel name="SummaryClockPanel" />
 	</screen>
 
-<!-- generic-->
-	<screen name="ScreenSummary" position="0,0" size="220,176">
-		<widget source="Title" render="Label" position="0,38" size="220,26" font="FdLcD;24" noWrap="1" />
+<!-- generic -->
+	<screen name="ScreenSummary" position="fill" flags="wfNoBorder">
+		<widget source="Title" render="Label" position="0,38" size="e,27" font="FdLcD;24" noWrap="1" transparent="1" />
 		<panel name="SummaryIconsPanel" />
 		<panel name="SummaryTunerStatusPanel" />
 		<panel name="SummaryClockPanel" />
 	</screen>
 
-<!-- menus-->
-	<screen name="MenuSummary" position="0,0" size="220,176">
+<!-- menus -->
+	<screen name="MenuSummary" position="fill" flags="wfNoBorder">
 		<panel name="ScreenSummary" />
-		<widget source="entry" render="Label" position="0,66" size="220,20" font="FdLcD;19" noWrap="1" />
+		<widget source="entry" render="Label" position="0,67" size="e,22" font="FdLcD;19" noWrap="1" transparent="1" />
 	</screen>
 
-<!-- setup-->
-	<screen name="SetupSummary" position="0,0" size="220,176">
+<!-- setup -->
+	<screen name="SetupSummary" position="fill" flags="wfNoBorder">
 		<panel name="MenuSummary" />
-		<widget source="value" render="Label" position="0,93" size="220,19" font="FdLcD;17" noWrap="1" />
+		<widget source="value" render="Label" position="0,91" size="e,20" font="FdLcD;17" noWrap="1" transparent="1" />
 	</screen>
 
-<!-- movieplayer-->
+<!-- movieplayer -->
 	<screen name="InfoBarMoviePlayerSummary" position="0,0" size="220,176">
 		<widget name="statusicon_summary" position="0,138" size="40,38" pixmaps="play.png,pause.png,stop.png,forward.png,backward.png,slow.png" />
 		<widget source="speed_summary" render="Label" position="44,140" size="160,32" font="FdLcD;26" halign="left" noWrap="1" />
@@ -163,6 +165,7 @@
 		<panel name="SummaryTunerStatusPanel" />
 		<panel name="SummaryClockPanel" />
 	</screen>
+
 	<screen name="MovieContextMenuSummary" position="0,0" size="220,176">
 		<widget source="parent.Title" render="Label" position="0,38" size="220,26" font="FdLcD;24" halign="left" valign="top" noWrap="1" />
 		<widget source="selected" render="Label" position="0,66" size="220,20" font="FdLcD;19" halign="left" valign="top" />
@@ -170,6 +173,7 @@
 		<panel name="SummaryTunerStatusPanel" />
 		<panel name="SummaryClockPanel" />
 	</screen>
+
 	<screen name="MovieSelectionSummary" position="0,0" size="220,176">
 		<widget source="parent.Service" render="Label" position="0,38" size="220,26" font="FdLcD;24" halign="left" noWrap="1">
 			<convert type="MovieInfo">RecordServiceName</convert>
@@ -187,7 +191,7 @@
 		<panel name="SummaryClockPanel" />
 	</screen>
 
-<!-- channelselection-->
+<!-- channelselection -->
 	<screen name="ChannelSelection_summary" position="0,0" size="220,176">
 		<widget source="parent.ServiceEvent" render="Label" position="0,38" size="220,26" font="FdLcD;24" halign="left" noWrap="1">
 			<convert type="ServiceName">Name</convert>
@@ -198,7 +202,7 @@
 		<widget source="parent.ServiceEvent" render="Progress" position="0,93" size="220,10" borderWidth="1">
 			<convert type="EventTime">Progress</convert>
 		</widget>
-		<widget source="parent.ServiceEvent" render="Label" position="0,106" size="220,36" font="FdLcD;34" halign="left" valign="bottom" noWrap="1">
+		<widget source="parent.ServiceEvent" render="Label" position="0,106" size="220,35" font="FdLcD;30" halign="center" valign="bottom" noWrap="1">
 			<convert type="EventTime">VFDRemaining</convert>
 			<convert type="RemainingToText">VFDNoSeconds</convert>
 		</widget>
@@ -228,12 +232,9 @@
 	</screen>
 
 <!-- Plugin browser -->
-	<screen name="PluginBrowserSummary" position="0,0" size="220,176">
-		<widget source="parent.Title" render="Label" position="0,38" size="220,26" font="FdLcD;24" halign="left" noWrap="1" />
-		<widget source="entry" render="Label" position="0,66" size="220,20" font="FdLcD;19" halign="left" noWrap="1" />
-		<widget source="desc" render="Label" position="0,93" size="220,16" font="FdLcD;14" halign="left" transparent="1" />
-		<panel name="SummaryIconsPanel" />
-		<panel name="SummaryClockPanel" />
+	<screen name="PluginBrowserSummary" position="fill" flags="wfNoBorder">
+		<panel name="MenuSummary" />
+		<widget source="desc" render="Label" position="0,91" size="e,17" font="FdLcD;14" noWrap="1" transparent="1" />
 	</screen>
 
 <!-- JobView Summary -->

--- a/data/display220/skin_display.xml
+++ b/data/display220/skin_display.xml
@@ -18,13 +18,13 @@
 	</windowstyle>
 
 	<fonts>
-		<!-- pick a funky name for the font, so we don't conflict  -->
+		<!-- Pick a funky name for the font, so we don't conflict. -->
 		<font filename="nmsbd.ttf" name="FdLcD" scale="100"/>
 	</fonts>
 
-<!-- template -->
+<!-- Templates -->
 	<screen name="SummaryClockPanel">
-		<widget source="global.CurrentTime" render="Label" position="0,e-40" size="e,40" font="FdLcD;35" halign="right" valign="bottom" noWrap="1">
+		<widget source="global.CurrentTime" render="Label" position="0,e-40" size="e,40" font="FdLcD;36" halign="right" valign="bottom" noWrap="1">
 			<convert type="ClockToText"/>
 		</widget>
 	</screen>
@@ -108,7 +108,27 @@
 		</widget>
 	</screen>
 
-<!-- main -->
+<!-- Standby -->
+	<screen name="StandbySummary" position="fill" flags="wfNoBorder">
+		<widget source="global.CurrentTime" render="Label" position="0,0" size="220,24" font="FdLcD;22" halign="left"  noWrap="1">
+			<convert type="ClockToText">FullDate</convert>
+		</widget>
+		<widget source="global.CurrentTime" render="Label" position="0,22" size="225,100" font="FdLcD;85" halign="left" noWrap="1">
+			<convert type="ClockToText">Format:%H:%M</convert>
+		</widget>
+		<widget source="global.OnlineStableUpdateState" render="Pixmap" pixmap="update_stable.png" position="135,146" size="30,30" >
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="global.OnlineUnstableUpdateState" render="Pixmap" pixmap="update_unstable.png" position="135,146" size="30,30" >
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="session.RecordState" render="Pixmap" pixmap="rec.png" position="170,150"  size="50,26">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<panel name="SummaryTunerStatusPanel" />
+	</screen>
+
+<!-- Main -->
 	<screen name="InfoBarSummary" position="0,0" size="220,176">
 		<widget source="session.CurrentService" render="Label" position="0,38" size="220,26" font="FdLcD;24" halign="left" noWrap="1" >
 			<convert type="ServiceName">NameOnly</convert>
@@ -128,7 +148,7 @@
 		<panel name="SummaryClockPanel" />
 	</screen>
 
-<!-- generic -->
+<!-- Generic Screen -->
 	<screen name="ScreenSummary" position="fill" flags="wfNoBorder">
 		<widget source="Title" render="Label" position="0,38" size="e,27" font="FdLcD;24" noWrap="1" transparent="1" />
 		<panel name="SummaryIconsPanel" />
@@ -136,21 +156,27 @@
 		<panel name="SummaryClockPanel" />
 	</screen>
 
-<!-- menus -->
+<!-- Menu -->
 	<screen name="MenuSummary" position="fill" flags="wfNoBorder">
 		<panel name="ScreenSummary" />
 		<widget source="entry" render="Label" position="0,67" size="e,22" font="FdLcD;19" noWrap="1" transparent="1" />
 	</screen>
 
-<!-- setup -->
+<!-- Setup -->
 	<screen name="SetupSummary" position="fill" flags="wfNoBorder">
 		<panel name="MenuSummary" />
 		<widget source="value" render="Label" position="0,91" size="e,20" font="FdLcD;17" noWrap="1" transparent="1" />
 	</screen>
 
-<!-- skinselector -->
+<!-- Skin Selector -->
 	<screen name="SkinSelectorSummary" position="fill" flags="wfNoBorder">
 		<panel name="MenuSummary" />
+	</screen>
+
+<!-- Plugin Browser -->
+	<screen name="PluginBrowserSummary" position="fill" flags="wfNoBorder">
+		<panel name="MenuSummary" />
+		<widget source="desc" render="Label" position="0,91" size="e,17" font="FdLcD;14" noWrap="1" transparent="1" />
 	</screen>
 
 <!-- movieplayer -->
@@ -214,32 +240,6 @@
 		<panel name="SummaryIconsPanel" />
 		<panel name="SummaryTunerStatusPanel" />
 		<panel name="SummaryClockPanel" />
-	</screen>
-
-<!-- standby -->
-	<screen name="StandbySummary" position="0,0" size="220,176">
-		<widget source="global.CurrentTime" render="Label" position="0,0" size="220,24" font="FdLcD;22" halign="left"  noWrap="1">
-			<convert type="ClockToText">FullDate</convert>
-		</widget>
-		<widget source="global.CurrentTime" render="Label" position="0,22" size="225,100" font="FdLcD;85" halign="left" noWrap="1">
-			<convert type="ClockToText">Format:%H:%M</convert>
-		</widget>
-		<widget source="global.OnlineStableUpdateState" render="Pixmap" pixmap="update_stable.png" position="135,146" size="30,30" >
-			<convert type="ConditionalShowHide"/>
-		</widget>
-		<widget source="global.OnlineUnstableUpdateState" render="Pixmap" pixmap="update_unstable.png" position="135,146" size="30,30" >
-			<convert type="ConditionalShowHide"/>
-		</widget>
-		<widget source="session.RecordState" render="Pixmap" pixmap="rec.png" position="170,150"  size="50,26">
-			<convert type="ConditionalShowHide"/>
-		</widget>
-		<panel name="SummaryTunerStatusPanel" />
-	</screen>
-
-<!-- Plugin browser -->
-	<screen name="PluginBrowserSummary" position="fill" flags="wfNoBorder">
-		<panel name="MenuSummary" />
-		<widget source="desc" render="Label" position="0,91" size="e,17" font="FdLcD;14" noWrap="1" transparent="1" />
 	</screen>
 
 <!-- JobView Summary -->

--- a/data/display220/skin_display.xml
+++ b/data/display220/skin_display.xml
@@ -148,6 +148,11 @@
 		<widget source="value" render="Label" position="0,91" size="e,20" font="FdLcD;17" noWrap="1" transparent="1" />
 	</screen>
 
+<!-- skinselector -->
+	<screen name="SkinSelectorSummary" position="fill" flags="wfNoBorder">
+		<panel name="MenuSummary" />
+	</screen>
+
 <!-- movieplayer -->
 	<screen name="InfoBarMoviePlayerSummary" position="0,0" size="220,176">
 		<widget name="statusicon_summary" position="0,138" size="40,38" pixmaps="play.png,pause.png,stop.png,forward.png,backward.png,slow.png" />

--- a/data/display220/skin_display.xml
+++ b/data/display220/skin_display.xml
@@ -168,6 +168,12 @@
 		<widget source="value" render="Label" position="0,91" size="e,20" font="FdLcD;17" noWrap="1" transparent="1" />
 	</screen>
 
+<!-- About -->
+	<screen name="AboutSummary" position="fill" flags="wfNoBorder">
+		<widget source="Title" render="Label" position="0,0" size="e,27" font="FdLcD;24" noWrap="1" transparent="1" />
+		<widget source="about" render="Label" position="0,30" size="e,e-30" font="FdLcD;12" noWrap="1" transparent="1" />
+	</screen>
+
 <!-- Skin Selector -->
 	<screen name="SkinSelectorSummary" position="fill" flags="wfNoBorder">
 		<panel name="MenuSummary" />
@@ -301,10 +307,6 @@
 	<screen name="MessageBoxSimple_summary" position="0,0" size="220,176">
 		<widget source="parent.Text" render="Label" position="0,0" size="220,176" font="FdLcD;17" halign="center" />
 		<widget source="parent.selectedChoice" render="Label" position="0,135" size="220,28" font="FdLcD;26" halign="center" noWrap="1" />
-	</screen>
-
-	<screen name="AboutSummary" position="0,0" size="220,176">
-		<widget source="AboutText" render="Label" position="0,0" size="220,176" font="FdLcD;11" />
 	</screen>
 
 	<screen name="TimerEditListSummary" position="0,0" size="220,176">

--- a/data/display220/skin_display_picon.xml
+++ b/data/display220/skin_display_picon.xml
@@ -126,6 +126,11 @@
 		<widget source="value" render="Label" position="0,91" size="e,20" font="FdLcD;17" noWrap="1" transparent="1" />
 	</screen>
 
+<!-- skinselector -->
+	<screen name="SkinSelectorSummary" position="fill" flags="wfNoBorder">
+		<panel name="MenuSummary" />
+	</screen>
+
 <!-- movieplayer -->
 	<screen name="InfoBarMoviePlayerSummary" position="0,0" size="220,176">
 		<widget name="statusicon_summary" position="0,138" size="40,38" pixmaps="play.png,pause.png,stop.png,forward.png,backward.png,slow.png" />

--- a/data/display220/skin_display_picon.xml
+++ b/data/display220/skin_display_picon.xml
@@ -18,13 +18,13 @@
 	</windowstyle>
 
 	<fonts>
-		<!-- pick a funky name for the font, so we don't conflict  -->
+		<!-- Pick a funky name for the font, so we don't conflict. -->
 		<font filename="nmsbd.ttf" name="FdLcD" scale="100"/>
 	</fonts>
 
-<!-- template -->
+<!-- Templates -->
 	<screen name="SummaryClockPanel">
-		<widget source="global.CurrentTime" render="Label" position="120,142" size="100,45" font="FdLcD;40" halign="right" valign="bottom" noWrap="1">
+		<widget source="global.CurrentTime" render="Label" position="0,e-40" size="e,40" font="FdLcD;36" halign="right" valign="bottom" noWrap="1">
 			<convert type="ClockToText"/>
 		</widget>
 	</screen>
@@ -98,7 +98,27 @@
 		</widget>
 	</screen>
 
-<!-- main -->
+<!-- Standby -->
+	<screen name="StandbySummary" position="fill" flags="wfNoBorder">
+		<widget source="global.CurrentTime" render="Label" position="0,0" size="220,24" font="FdLcD;22" halign="left"  noWrap="1">
+			<convert type="ClockToText">FullDate</convert>
+		</widget>
+		<widget source="global.CurrentTime" render="Label" position="0,22" size="225,100" font="FdLcD;85" halign="left" noWrap="1">
+			<convert type="ClockToText">Format:%H:%M</convert>
+		</widget>
+		<widget source="global.OnlineStableUpdateState" render="Pixmap" pixmap="update_stable.png" position="135,146" size="30,30" >
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="global.OnlineUnstableUpdateState" render="Pixmap" pixmap="update_unstable.png" position="135,146" size="30,30" >
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="session.RecordState" render="Pixmap" pixmap="rec.png" position="170,150"  size="50,26">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<panel name="SummaryTunerStatusPanel" />
+	</screen>
+
+<!-- Main -->
 	<screen name="InfoBarSummary" position="0,0" size="220,176">
 		<widget source="session.CurrentService" render="LcdPicon" position="0,35" size="220,132" zPosition="1" alphatest="on">
 			<convert type="ServiceName">Reference</convert>
@@ -106,7 +126,7 @@
 		<panel name="SummaryIconsPanel" />
 	</screen>
 
-<!-- generic -->
+<!-- Generic Screen -->
 	<screen name="ScreenSummary" position="fill" flags="wfNoBorder">
 		<widget source="Title" render="Label" position="0,38" size="e,27" font="FdLcD;24" noWrap="1" transparent="1" />
 		<panel name="SummaryIconsPanel" />
@@ -114,21 +134,27 @@
 		<panel name="SummaryClockPanel" />
 	</screen>
 
-<!-- menus -->
+<!-- Menu -->
 	<screen name="MenuSummary" position="fill" flags="wfNoBorder">
 		<panel name="ScreenSummary" />
 		<widget source="entry" render="Label" position="0,67" size="e,22" font="FdLcD;19" noWrap="1" transparent="1" />
 	</screen>
 
-<!-- setup -->
+<!-- Setup -->
 	<screen name="SetupSummary" position="fill" flags="wfNoBorder">
 		<panel name="MenuSummary" />
 		<widget source="value" render="Label" position="0,91" size="e,20" font="FdLcD;17" noWrap="1" transparent="1" />
 	</screen>
 
-<!-- skinselector -->
+<!-- Skin Selector -->
 	<screen name="SkinSelectorSummary" position="fill" flags="wfNoBorder">
 		<panel name="MenuSummary" />
+	</screen>
+
+<!-- Plugin Browser -->
+	<screen name="PluginBrowserSummary" position="fill" flags="wfNoBorder">
+		<panel name="MenuSummary" />
+		<widget source="desc" render="Label" position="0,91" size="e,17" font="FdLcD;14" noWrap="1" transparent="1" />
 	</screen>
 
 <!-- movieplayer -->
@@ -180,32 +206,6 @@
 			<convert type="ServiceName">Reference</convert>
 		</widget>
 		<panel name="SummaryIconsPanel" />
-	</screen>
-
-<!-- standby -->
-	<screen name="StandbySummary" position="0,0" size="220,176">
-		<widget source="global.CurrentTime" render="Label" position="0,0" size="220,24" font="FdLcD;22" halign="left"  noWrap="1">
-			<convert type="ClockToText">FullDate</convert>
-		</widget>
-		<widget source="global.CurrentTime" render="Label" position="0,22" size="225,100" font="FdLcD;85" halign="left" noWrap="1">
-			<convert type="ClockToText">Format:%H:%M</convert>
-		</widget>
-		<widget source="global.OnlineStableUpdateState" render="Pixmap" pixmap="update_stable.png" position="135,146" size="30,30" >
-			<convert type="ConditionalShowHide"/>
-		</widget>
-		<widget source="global.OnlineUnstableUpdateState" render="Pixmap" pixmap="update_unstable.png" position="135,146" size="30,30" >
-			<convert type="ConditionalShowHide"/>
-		</widget>
-		<widget source="session.RecordState" render="Pixmap" pixmap="rec.png" position="170,150"  size="50,26">
-			<convert type="ConditionalShowHide"/>
-		</widget>
-		<panel name="SummaryTunerStatusPanel" />
-	</screen>
-
-<!-- Plugin browser -->
-	<screen name="PluginBrowserSummary" position="fill" flags="wfNoBorder">
-		<panel name="MenuSummary" />
-		<widget source="desc" render="Label" position="0,91" size="e,17" font="FdLcD;14" noWrap="1" transparent="1" />
 	</screen>
 
 <!-- JobView Summary -->

--- a/data/display220/skin_display_picon.xml
+++ b/data/display220/skin_display_picon.xml
@@ -146,6 +146,12 @@
 		<widget source="value" render="Label" position="0,91" size="e,20" font="FdLcD;17" noWrap="1" transparent="1" />
 	</screen>
 
+<!-- About -->
+	<screen name="AboutSummary" position="fill" flags="wfNoBorder">
+		<widget source="Title" render="Label" position="0,0" size="e,27" font="FdLcD;24" noWrap="1" transparent="1" />
+		<widget source="about" render="Label" position="0,30" size="e,e-30" font="FdLcD;12" noWrap="1" transparent="1" />
+	</screen>
+
 <!-- Skin Selector -->
 	<screen name="SkinSelectorSummary" position="fill" flags="wfNoBorder">
 		<panel name="MenuSummary" />

--- a/data/display220/skin_display_picon.xml
+++ b/data/display220/skin_display_picon.xml
@@ -16,6 +16,7 @@
 		<color color="#ffffff" name="WindowTitleForeground"/>
 		<color color="#000000" name="WindowTitleBackground"/>
 	</windowstyle>
+
 	<fonts>
 		<!-- pick a funky name for the font, so we don't conflict  -->
 		<font filename="nmsbd.ttf" name="FdLcD" scale="100"/>
@@ -47,6 +48,7 @@
 			<convert type="ConditionalShowHide" />
 		</widget>
 	</screen>
+
 	<screen name="SummaryTunerStatusPanel">
 		<widget source="session.TunerInfo" render="Pixmap" pixmap="tuner-a.png" position="0,143" size="19,33">
 			<convert type="TunerInfo">TunerUseMask</convert>
@@ -96,7 +98,7 @@
 		</widget>
 	</screen>
 
-<!-- main-->
+<!-- main -->
 	<screen name="InfoBarSummary" position="0,0" size="220,176">
 		<widget source="session.CurrentService" render="LcdPicon" position="0,35" size="220,132" zPosition="1" alphatest="on">
 			<convert type="ServiceName">Reference</convert>
@@ -104,27 +106,27 @@
 		<panel name="SummaryIconsPanel" />
 	</screen>
 
-<!-- generic-->
-	<screen name="ScreenSummary" position="0,0" size="220,176">
-		<widget source="Title" render="Label" position="0,38" size="220,26" font="FdLcD;24" noWrap="1" />
+<!-- generic -->
+	<screen name="ScreenSummary" position="fill" flags="wfNoBorder">
+		<widget source="Title" render="Label" position="0,38" size="e,27" font="FdLcD;24" noWrap="1" transparent="1" />
 		<panel name="SummaryIconsPanel" />
 		<panel name="SummaryTunerStatusPanel" />
 		<panel name="SummaryClockPanel" />
 	</screen>
 
-<!-- menus-->
-	<screen name="MenuSummary" position="0,0" size="220,176">
+<!-- menus -->
+	<screen name="MenuSummary" position="fill" flags="wfNoBorder">
 		<panel name="ScreenSummary" />
-		<widget source="entry" render="Label" position="0,66" size="220,20" font="FdLcD;19" noWrap="1" />
+		<widget source="entry" render="Label" position="0,67" size="e,22" font="FdLcD;19" noWrap="1" transparent="1" />
 	</screen>
 
-<!-- setup-->
-	<screen name="SetupSummary" position="0,0" size="220,176">
+<!-- setup -->
+	<screen name="SetupSummary" position="fill" flags="wfNoBorder">
 		<panel name="MenuSummary" />
-		<widget source="value" render="Label" position="0,93" size="220,19" font="FdLcD;17" noWrap="1" />
+		<widget source="value" render="Label" position="0,91" size="e,20" font="FdLcD;17" noWrap="1" transparent="1" />
 	</screen>
 
-<!-- movieplayer-->
+<!-- movieplayer -->
 	<screen name="InfoBarMoviePlayerSummary" position="0,0" size="220,176">
 		<widget name="statusicon_summary" position="0,138" size="40,38" pixmaps="play.png,pause.png,stop.png,forward.png,backward.png,slow.png" />
 		<widget source="speed_summary" render="Label" position="44,140" size="160,32" font="FdLcD;26" halign="left" noWrap="1" />
@@ -141,6 +143,7 @@
 		<panel name="SummaryTunerStatusPanel" />
 		<panel name="SummaryClockPanel" />
 	</screen>
+
 	<screen name="MovieContextMenuSummary" position="0,0" size="220,176">
 		<widget source="parent.Title" render="Label" position="0,38" size="220,26" font="FdLcD;24" halign="left" valign="top" noWrap="1" />
 		<widget source="selected" render="Label" position="0,66" size="220,20" font="FdLcD;19" halign="left" valign="top" />
@@ -148,6 +151,7 @@
 		<panel name="SummaryTunerStatusPanel" />
 		<panel name="SummaryClockPanel" />
 	</screen>
+
 	<screen name="MovieSelectionSummary" position="0,0" size="220,176">
 		<widget source="parent.Service" render="Label" position="0,38" size="220,26" font="FdLcD;24" halign="left" noWrap="1">
 			<convert type="MovieInfo">RecordServiceName</convert>
@@ -165,7 +169,7 @@
 		<panel name="SummaryClockPanel" />
 	</screen>
 
-<!-- channelselection-->
+<!-- channelselection -->
 	<screen name="ChannelSelection_summary" position="0,0" size="220,176">
 		<widget source="parent.ServiceEvent" render="LcdPicon" position="0,35" size="220,132" zPosition="1" alphatest="on">
 			<convert type="ServiceName">Reference</convert>
@@ -194,12 +198,9 @@
 	</screen>
 
 <!-- Plugin browser -->
-	<screen name="PluginBrowserSummary" position="0,0" size="220,176">
-		<widget source="parent.Title" render="Label" position="0,38" size="220,26" font="FdLcD;24" halign="left" noWrap="1" />
-		<widget source="entry" render="Label" position="0,66" size="220,20" font="FdLcD;19" halign="left" noWrap="1" />
-		<widget source="desc" render="Label" position="0,93" size="220,16" font="FdLcD;14" halign="left" transparent="1" />
-		<panel name="SummaryIconsPanel" />
-		<panel name="SummaryClockPanel" />
+	<screen name="PluginBrowserSummary" position="fill" flags="wfNoBorder">
+		<panel name="MenuSummary" />
+		<widget source="desc" render="Label" position="0,91" size="e,17" font="FdLcD;14" noWrap="1" transparent="1" />
 	</screen>
 
 <!-- JobView Summary -->

--- a/lib/python/Screens/About.py
+++ b/lib/python/Screens/About.py
@@ -14,7 +14,7 @@ from Components.Pixmap import MultiPixmap
 from Components.ScrollLabel import ScrollLabel
 from Components.Sources.StaticText import StaticText
 from Components.SystemInfo import SystemInfo
-from Screen import Screen
+from Screen import Screen, ScreenSummary
 from Screens.GitCommitInfo import CommitInfo
 from Screens.SoftwareUpdate import UpdatePlugin
 from Tools.Directories import fileExists, fileCheck, pathExists
@@ -649,29 +649,24 @@ class SystemNetworkInfo(Screen):
 		return AboutSummary
 
 
-class AboutSummary(Screen):
+class AboutSummary(ScreenSummary):
 	def __init__(self, session, parent):
-		Screen.__init__(self, session, parent=parent)
-		self["selected"] = StaticText("ViX:" + getImageVersion())
-
-		AboutText = _("Model: %s %s\n") % (getMachineBrand(), getMachineName())
-
+		ScreenSummary.__init__(self, session, parent=parent)
+		self.skinName = "AboutSummary"
+		aboutText = _("Model: %s %s\n") % (getMachineBrand(), getMachineName())
 		if path.exists('/proc/stb/info/chipset'):
 			chipset = open('/proc/stb/info/chipset', 'r').read()
-			AboutText += _("Chipset: BCM%s") % chipset.replace('\n', '') + "\n"
-
-		AboutText += _("Version: %s") % getImageVersion() + "\n"
-		AboutText += _("Build: %s") % getImageBuild() + "\n"
-		AboutText += _("Kernel: %s") % about.getKernelVersionString() + "\n"
-
+			aboutText += _("Chipset: BCM%s") % chipset.replace('\n', '') + "\n"
+		aboutText += _("Version: %s") % getImageVersion() + "\n"
+		aboutText += _("Build: %s") % getImageBuild() + "\n"
+		aboutText += _("Kernel: %s") % about.getKernelVersionString() + "\n"
 		string = getDriverDate()
 		year = string[0:4]
 		month = string[4:6]
 		day = string[6:8]
 		driversdate = '-'.join((year, month, day))
-		AboutText += _("Drivers: %s") % driversdate + "\n"
-		AboutText += _("Last update: %s") % getEnigmaVersionString() + "\n\n"
-
+		aboutText += _("Drivers: %s") % driversdate + "\n"
+		aboutText += _("Last update: %s") % getEnigmaVersionString() + "\n\n"
 		tempinfo = ""
 		if path.exists('/proc/stb/sensors/temp0/value'):
 			with open('/proc/stb/sensors/temp0/value', 'r') as f:
@@ -684,9 +679,9 @@ class AboutSummary(Screen):
 				tempinfo = f.read()
 		if tempinfo and int(tempinfo.replace('\n', '')) > 0:
 			mark = str('\xc2\xb0')
-			AboutText += _("System temperature: %s") % tempinfo.replace('\n', '') + mark + "C\n\n"
+			aboutText += _("System temperature: %s") % tempinfo.replace('\n', '') + mark + "C\n\n"
+		self["about"] = StaticText(aboutText)
 
-		self["AboutText"] = StaticText(AboutText)
 
 class TranslationInfo(Screen):
 	def __init__(self, session):

--- a/lib/python/Screens/PluginBrowser.py
+++ b/lib/python/Screens/PluginBrowser.py
@@ -17,7 +17,7 @@ from Screens.ChoiceBox import ChoiceBox
 from Screens.Console import Console
 from Screens.MessageBox import MessageBox
 from Screens.ParentalControlSetup import ProtectedScreen
-from Screens.Screen import Screen
+from Screens.Screen import Screen, ScreenSummary
 from Tools.Directories import resolveFilename, SCOPE_PLUGINS, SCOPE_ACTIVE_SKIN
 from Tools.LoadPixmap import LoadPixmap
 from time import time
@@ -44,9 +44,10 @@ def languageChanged():
 	plugins.clearPluginList()
 	plugins.readPluginList(resolveFilename(SCOPE_PLUGINS))
 
-class PluginBrowserSummary(Screen):
+class PluginBrowserSummary(ScreenSummary):
 	def __init__(self, session, parent):
-		Screen.__init__(self, session, parent = parent)
+		ScreenSummary.__init__(self, session, parent=parent)
+		# self.skinSummary = "ScreenSummary"
 		self["entry"] = StaticText("")
 		self["desc"] = StaticText("")
 		self.onShow.append(self.addWatcher)

--- a/lib/python/Screens/SkinSelector.py
+++ b/lib/python/Screens/SkinSelector.py
@@ -13,7 +13,7 @@ from Components.Sources.List import List
 from Components.Sources.StaticText import StaticText
 from Screens.HelpMenu import HelpableScreen
 from Screens.MessageBox import MessageBox
-from Screens.Screen import Screen
+from Screens.Screen import Screen, ScreenSummary
 from Screens.Standby import TryQuitMainloop, QUIT_RESTART
 from Tools.Directories import resolveFilename, SCOPE_CURRENT_SKIN, SCOPE_LCDSKIN, SCOPE_SKIN
 
@@ -270,22 +270,24 @@ class LcdSkinSelector(SkinSelector):
 		self.xmlList = ["skin_display.xml", "skin_display_picon.xml"]
 
 
-class SkinSelectorSummary(Screen):
+class SkinSelectorSummary(ScreenSummary):
 	def __init__(self, session, parent):
-		Screen.__init__(self, session, parent=parent)
-		self["Name"] = StaticText("")
+		ScreenSummary.__init__(self, session, parent=parent)
+		self["entry"] = StaticText("")
 		if hasattr(self.parent, "onChangedEntry"):
-			self.onShow.append(self.addWatcher)
-			self.onHide.append(self.removeWatcher)
+			if self.addWatcher not in self.onShow:
+				self.onShow.append(self.addWatcher)
+			if self.removeWatcher not in self.onHide:
+				self.onHide.append(self.removeWatcher)
 
 	def addWatcher(self):
-		if hasattr(self.parent, "onChangedEntry"):
+		if self.selectionChanged not in self.parent.onChangedEntry:
 			self.parent.onChangedEntry.append(self.selectionChanged)
-			self.selectionChanged()
+		self.selectionChanged()
 
 	def removeWatcher(self):
-		if hasattr(self.parent, "onChangedEntry"):
+		if self.selectionChanged in self.parent.onChangedEntry:
 			self.parent.onChangedEntry.remove(self.selectionChanged)
 
 	def selectionChanged(self):
-		self["Name"].text = self.parent.getCurrentName()
+		self["entry"].text = self.parent.getCurrentName()

--- a/lib/python/Screens/Standby.py
+++ b/lib/python/Screens/Standby.py
@@ -14,7 +14,7 @@ from Components.SystemInfo import SystemInfo
 from Components.Sources.StaticText import StaticText
 from Components.Sources.StreamService import StreamServiceList
 import Screens.InfoBar
-from Screens.Screen import Screen
+from Screens.Screen import Screen, ScreenSummary
 from Tools import Notifications
 
 inStandby = None
@@ -182,7 +182,7 @@ class Standby(Standby2):
 	def doStandby(self):
 		Notifications.AddNotification(Screens.Standby.Standby2)
 
-class StandbySummary(Screen):
+class StandbySummary(ScreenSummary):
 	skin = """
 	<screen position="0,0" size="132,64">
 		<widget source="global.CurrentTime" render="Label" position="0,0" size="132,64" font="Regular;40" halign="center">


### PR DESCRIPTION
[skin_desplay.xml] Optimise display220 skin
- Improve skin for new SummaryScreen class and its derivatives.

[skin_desplay_picon.xml] Optimise display220 skin
- Improve skin for new SummaryScreen class and its derivatives.

[PluginBrowser.py] Use ScreenSummary class
- Use the new SummaryScreen class rather than Screen for the display screen.

[SkinSelector.py] Use ScreenSummary class
- Use the new SummaryScreen class rather than Screen for the display screen.

[skin_display.xml] Add SkinSelectorSummary screen

[skin_display_picon.xml] Add SkinSelectorSummary screen

[Standby.py] Use ScreenSummary class
- Use the new SummaryScreen class rather than Screen for the display screen.

[skin_display.xml] More skin tidy up

[skin_display_picon.xml] More skin tidy up

There will be more changes to come.
