### PR TITLE
[UpdateChoices] ActionMap fixup after ChoiceBox changes

### DIFF
--- a/lib/python/Screens/SoftwareUpdate.py
+++ b/lib/python/Screens/SoftwareUpdate.py
@@ -60,31 +60,10 @@ class UpdateChoices(ChoiceBox):
 			self['tl_yellow'] = Pixmap()
 			self['tl_green'] = Pixmap()
 
-		self["actions"] = NumberActionMap(["WizardActions", "InputActions", "ColorActions", "DirectionActions", "MenuActions"],
+		self["menuActions"] = NumberActionMap(["MenuActions"],
 		{
-			"ok": self.go,
-			"1": self.keyNumberGlobal,
-			"2": self.keyNumberGlobal,
-			"3": self.keyNumberGlobal,
-			"4": self.keyNumberGlobal,
-			"5": self.keyNumberGlobal,
-			"6": self.keyNumberGlobal,
-			"7": self.keyNumberGlobal,
-			"8": self.keyNumberGlobal,
-			"9": self.keyNumberGlobal,
-			"0": self.keyNumberGlobal,
-			"red": self.keyRed,
-			"green": self.keyGreen,
-			"yellow": self.keyYellow,
-			"blue": self.keyBlue,
-			"up": self.up,
-			"down": self.down,
-			"left": self.left,
-			"right": self.right,
-			"shiftUp": self.additionalMoveUp,
-			"shiftDown": self.additionalMoveDown,
 			"menu": self.opensettings
-		}, prio=-2)
+		}, prio=-3) # Override ChoiceBox "menu" action
 		self.onShown.append(self.onshow)
 
 	def onshow(self):


### PR DESCRIPTION
Reduce the actionmap in UpdateChoices to the minimum needed by the
class, and rename it from "actions" to "menuActions" so that it
doesn't overwrite the "actions" ActionMap in the parent class.

This fixes the break of the EXIT button in this class introduced
in commit 2811605, which merged the "back" action in the ChoiceBox
"cancelaction" ActionMap into the ChoiceBox "actions" ActionMap.

Because that action wasn't replicated in the UpdateChoices "actions"
ActionMap, the overwrite of the parent's ActionMap cause the "back"
action to be lost.