### PR TITLE
[Screen.py] Update to new screen standards

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -70,7 +70,7 @@
 		<item level="2" text="Show crypto info in infobar" description="Show encryption info in the infobar (when supported by the skin).">config.usage.show_cryptoinfo</item>
 		<item level="2" text="Infobar frontend data source" description="Configure the source of the frontend data as shown on the infobars. 'Settings' is as stored on the settings. 'Tuner' is as reported by the tuner.">config.usage.infobar_frontend_source</item>
 		<item level="2" text="Swap SNR in '&#37;' with SNR in 'db'" description="This option allows you to show the SNR as a percentage (not all receivers support this).">config.usage.swap_snr_on_osd</item>
-		<item level="1" text="Show full menu path" description="This option allows you to show the full menu path">config.usage.show_menupath</item>
+		<item level="1" text="Show screen path" description="This option allows you to show the full screen path leading to the current screen.">config.usage.showScreenPath</item>
 		<item level="1" text="Sort setting screens alphabetically" description="This option allows you to disable sorting of the option in setting screens">config.usage.sort_settings</item>
 		<item level="1" text="Sort menu screens alphabetically" description="This option allows you to disable sorting of the menus">config.usage.sort_menus</item>
 		<item level="0" text="Show menu numbers" description="This option allows you to show menu number quick links.">config.usage.menu_show_numbers</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -94,7 +94,19 @@ def InitUsageConfig():
 	config.usage.show_picon_bkgrn = ConfigSelection(default = "transparent", choices = [("none", _("Disabled")), ("transparent", _("Transparent")), ("blue", _("Blue")), ("red", _("Red")), ("black", _("Black")), ("white", _("White")), ("lightgrey", _("Light Grey")), ("grey", _("Grey"))])
 	config.usage.show_genre_info = ConfigYesNo(default=False)
 	config.usage.menu_show_numbers = ConfigYesNo(default = False)
-	config.usage.show_menupath = ConfigSelection(default = "small", choices = [("off", _("None")), ("small", _("Small")), ("large", _("Large"))])
+	config.usage.showScreenPath = ConfigSelection(default="small", choices=[("off", _("None")), ("small", _("Small")), ("large", _("Large"))])
+	# The following code is to be short lived and exists to transition
+	# settings from the old config.usage.show_menupath to the new
+	# config.usage.showScreenPath as this is the value to now shared
+	# by all images.  Thise code will transition the setting and then
+	# remove the old entry from user's settings files.
+	config.usage.show_menupath = ConfigSelection(default="small", choices=[("off", _("None")), ("small", _("Small")), ("large", _("Large"))])
+	if config.usage.show_menupath.value != config.usage.show_menupath.default:
+		config.usage.showScreenPath.value = config.usage.show_menupath.value
+		config.usage.show_menupath.value = config.usage.show_menupath.default
+		config.usage.save()
+		print("[UserConfig] DEBUG: The 'show_menupath' setting of '%s' has been transferred to 'showScreenPath'." % config.usage.showScreenPath.value)
+	# End of temporary code.
 	config.usage.show_spinner = ConfigYesNo(default = True)
 	config.usage.enable_tt_caching = ConfigYesNo(default = True)
 	config.usage.sort_settings = ConfigYesNo(default = False)

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -46,7 +46,6 @@ class Screen(dict):
 		self.summaries = CList()
 		self["Title"] = StaticText()
 		self["ScreenPath"] = StaticText()
-		self["menu_path_compressed"] = StaticText()  # Support legacy screen history skins.
 		self.screenPath = ""  # This is the current screen path without the title.
 		self.screenTitle = ""  # This is the current screen title without the path.
 
@@ -166,7 +165,6 @@ class Screen(dict):
 			screenPath = ""
 			screenTitle = title
 		self["ScreenPath"].text = screenPath
-		self["menu_path_compressed"].text = screenPath  # Support legacy screen history skins.
 		self["Title"].text = screenTitle
 
 	def getTitle(self):

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -155,10 +155,10 @@ class Screen(dict):
 		except AttributeError:
 			pass
 		self.screenTitle = title
-		if config.usage.show_menupath.value == "large":
+		if config.usage.showScreenPath.value == "large":
 			screenPath = ""
 			screenTitle = "%s > %s" % (self.screenPath, title) if self.screenPath else title
-		elif config.usage.show_menupath.value == "small":
+		elif config.usage.showScreenPath.value == "small":
 			screenPath = "%s >" % self.screenPath if self.screenPath else ""
 			screenTitle = title
 		else:

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -77,7 +77,7 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 				skin = setup.get("skin", "")
 				if skin != "":
 					self.skinName.insert(0, skin)
-				if config.usage.show_menupath.value in ("large", "small") and "menuTitle" in setup:
+				if config.usage.showScreenPath.value in ("large", "small") and "menuTitle" in setup:
 					title = setup.get("menuTitle", "").encode("UTF-8")
 				else:
 					title = setup.get("title", "").encode("UTF-8")


### PR DESCRIPTION
[Screen.py] Remove defunct "menu_path_compressed"
- All official OpenViX skins have now been updated to use the newer "ScreenPath" widget so the defunct "menu_path_compressed" widget can not be removed.

[UsageConfig.py] Transition screen path settings
- This temporary code will find the user's current value for the old "config.usage.show_menupath" setting and move it to the new "config.usage.showScreenPath".  The code will then remove the old "config.usage.show_menupath" entry from the settings file.

- This code is only run once such that when the setting is transferred the old setting is no longer used.  It is intended to remove this code after one or two production releases of OpenViX when it will be assumed that most users have had the setting transferred.  When this code is removed the only implication for users will be that the setting will not be migrated and the "config.usage.showScreenPath" default value will be used.  Also the old "config.usage.show_menupath" setting, if not at default, will not be removed.

[setup.xml] Use the new showScreenPath setting
- This change uses the new "config.usage.showScreenPath" setting and improves the label and description text to better reflect the functionality.

[Screen.py] Use new "config.usage.showScreenPath"
- This change replaces the old "config.usage.show_menupath" setting with the new and proposed common "config.usage.showScreenPath" setting.

[Setup.py] Use new "config.usage.showScreenPath"
- This change uses the new "config.usage.showScreenPath" setting to manage the title adjustments.
