### PR TITLE
[skin.py] Enable processing of templated screens

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -997,7 +997,11 @@ def readSkin(screen, skin, names, desktop):
 	if myScreen is None:  # Otherwise try embedded skin.
 		myScreen = getattr(screen, "parsedSkin", None)
 	if myScreen is None and getattr(screen, "skin", None):  # Try uncompiled embedded skin.
-		skin = screen.skin
+		if isinstance(screen.skin, list):
+			print("[Skin] Resizable embedded skin template found in '%s'." % name)
+			skin = screen.skin[0] % tuple([int(x * getSkinFactor()) for x in screen.skin[1:]])
+		else:
+			skin = screen.skin
 		print("[Skin] Parsing embedded skin '%s'." % name)
 		if isinstance(skin, tuple):
 			for s in skin:


### PR DESCRIPTION
This code allows embedded screens to be a template of a screen scaled to HD resolution together with scaling data to allow that screen to be resized to the current GUI resolution.
