### PR TITLE
Improve the Setup/ConfigList interface

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -144,8 +144,18 @@ class ConfigList(GUIComponent, object):
 
 
 class ConfigListScreen:
-	def __init__(self, list, session=None, on_change=None):
+	def __init__(self, list, session=None, on_change=None, fullUI=False):
 		self.entryChanged = on_change if on_change is not None else lambda: None
+		if fullUI:
+			if "key_red" not in self:
+				self["key_red"] = StaticText(_("Cancel"))
+			if "key_green" not in self:
+				self["key_green"] = StaticText(_("Save"))
+			self["fullUIActions"] = HelpableActionMap(self, ["ConfigListActions"], {
+				"cancel": (self.keyCancel, _("Cancel any changed settings and exit")),
+				"close": (self.closeRecursive, _("Cancel any changed settings and exit all menus")),
+				"save": (self.keySave, _("Save all changed settings and exit"))
+			}, prio=1, description=_("Common Setup Functions"))
 		if "key_menu" not in self:
 			self["key_menu"] = StaticText(_("MENU"))
 		if "HelpWindow" not in self:

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -4,7 +4,6 @@ from gettext import dgettext
 from os.path import getmtime, join as pathJoin
 from skin import setups
 
-from Components.ActionMap import HelpableActionMap
 from Components.config import ConfigBoolean, ConfigNothing, ConfigSelection, config
 from Components.ConfigList import ConfigListScreen
 from Components.Label import Label
@@ -40,7 +39,7 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 			self.skinName.append("Setup_%s" % setup)
 		self.skinName.append("Setup")
 		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry)
+		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry, fullUI=True)
 		self["footnote"] = Label()
 		self["footnote"].hide()
 		self["description"] = Label()
@@ -56,15 +55,6 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 				print("[Setup] Error: Unable to load menu image '%s'!" % menuimage)
 		else:
 			self.menuimage = None
-		if "key_red" not in self:
-			self["key_red"] = StaticText(_("Cancel"))
-		if "key_green" not in self:
-			self["key_green"] = StaticText(_("Save"))
-		self["actions"] = HelpableActionMap(self, ["ConfigListActions"], {
-			"cancel": (self.keyCancel, _("Cancel any changed settings and exit")),
-			"close": (self.closeRecursive, _("Cancel any changed settings and exit all menus")),
-			"save": (self.keySave, _("Save all changed settings and exit")),
-		}, prio=1, description=_("Common Setup Functions"))
 		self.createSetup()
 		if self.layoutFinished not in self.onLayoutFinish:
 			self.onLayoutFinish.append(self.layoutFinished)


### PR DESCRIPTION
[Setup.py] Use "fullUI" request to ConfigList.py
- This change asks ConfigList.py to offer the full UI interface, including the RED / GREEN cancel / save code support.

[ConfigList.py] Make RED/GREEN control optional
- This change allows the calling code to specify if the RED/GREEN, cancel/save, options should be controlled by this module.   The argument to control this actions if a Boolean "fullUI".  If set to False (the default) the code to operate as it did before the Setup/ConfigList refactor was started.  If set to True the code will offer a standardised UI to offer the RED/GREEN, cancel/save UI elements.

- The fullUI argument is optional and if not specified is False.  Currently the new Setup.py uses this argument but it is now available to any coders who would like to use a standardised Setup based UI.
