### PR TITLE
Various Menu improvements

### DIFF
--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -1,4 +1,4 @@
-from Screens.Screen import Screen
+from Screens.Screen import Screen, ScreenSummary
 from Screens.ParentalControlSetup import ProtectedScreen
 from Components.Sources.List import List
 from Components.ActionMap import NumberActionMap
@@ -44,23 +44,26 @@ class MenuUpdater:
 menuupdater = MenuUpdater()
 
 
-class MenuSummary(Screen):
+class MenuSummary(ScreenSummary):
 	def __init__(self, session, parent):
-		Screen.__init__(self, session, parent=parent)
-		self["MenuTitle"] = StaticText(parent.getTitle())
-		self["MenuEntry"] = StaticText("")
-		self.onShow.append(self.addWatcher)
-		self.onHide.append(self.removeWatcher)
+		ScreenSummary.__init__(self, session, parent=parent)
+		self["entry"] = StaticText("")  # DEBUG: Proposed for new summary screens.
+		if self.addWatcher not in self.onShow:
+			self.onShow.append(self.addWatcher)
+		if self.removeWatcher not in self.onHide:
+			self.onHide.append(self.removeWatcher)
 
 	def addWatcher(self):
-		self.parent["menu"].onSelectionChanged.append(self.selectionChanged)
+		if self.selectionChanged not in self.parent["menu"].onSelectionChanged:
+			self.parent["menu"].onSelectionChanged.append(self.selectionChanged)
 	 	self.selectionChanged()
 
 	def removeWatcher(self):
-		self.parent["menu"].onSelectionChanged.remove(self.selectionChanged)
+		if self.selectionChanged in self.parent["menu"].onSelectionChanged:
+			self.parent["menu"].onSelectionChanged.remove(self.selectionChanged)
 
 	def selectionChanged(self):
-		self["MenuEntry"].text = self.parent["menu"].getCurrent()[0]
+		self["entry"].text = self.parent["menu"].getCurrent()[0]  # DEBUG: Proposed for new summary screens.
 
 
 class Menu(Screen, ProtectedScreen):

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -1,7 +1,8 @@
+from Screens.HelpMenu import HelpableScreen
 from Screens.Screen import Screen, ScreenSummary
 from Screens.ParentalControlSetup import ProtectedScreen
 from Components.Sources.List import List
-from Components.ActionMap import NumberActionMap
+from Components.ActionMap import HelpableNumberActionMap
 from Components.Sources.StaticText import StaticText
 from Components.config import configfile
 from Components.PluginComponent import plugins
@@ -66,7 +67,7 @@ class MenuSummary(ScreenSummary):
 		self["entry"].text = self.parent["menu"].getCurrent()[0]  # DEBUG: Proposed for new summary screens.
 
 
-class Menu(Screen, ProtectedScreen):
+class Menu(Screen, HelpableScreen, ProtectedScreen):
 	ALLOW_SUSPEND = True
 
 	def okbuttonClick(self):
@@ -205,6 +206,7 @@ class Menu(Screen, ProtectedScreen):
 
 	def __init__(self, session, parent):
 		Screen.__init__(self, session)
+		HelpableScreen.__init__(self)
 		list = []
 
 		menuID = None
@@ -264,22 +266,23 @@ class Menu(Screen, ProtectedScreen):
 
 		self["menu"] = List(list)
 
-		self["actions"] = NumberActionMap(["OkCancelActions", "MenuActions", "NumberActions"],
-			{
-				"ok": self.okbuttonClick,
-				"cancel": self.closeNonRecursive,
-				"menu": self.closeRecursive,
-				"0": self.keyNumberGlobal,
-				"1": self.keyNumberGlobal,
-				"2": self.keyNumberGlobal,
-				"3": self.keyNumberGlobal,
-				"4": self.keyNumberGlobal,
-				"5": self.keyNumberGlobal,
-				"6": self.keyNumberGlobal,
-				"7": self.keyNumberGlobal,
-				"8": self.keyNumberGlobal,
-				"9": self.keyNumberGlobal
-			})
+		# self["menuActions"] = HelpableNumberActionMap(self, ["OkCancelActions", "MenuActions", "NumberActions"], {
+		self["menuActions"] = HelpableNumberActionMap(self, ["OkCancelActions", "NumberActions"], {
+			"ok": (self.okbuttonClick, _("Select the current menu item")),
+			"cancel": (self.closeNonRecursive, _("Exit menu")),
+			"close": (self.closeRecursive, _("Exit all menus")),
+			# "menu": (self.closeRecursive, _("Exit all menus")),
+			"1": (self.keyNumberGlobal, _("Direct menu item selection")),
+			"2": (self.keyNumberGlobal, _("Direct menu item selection")),
+			"3": (self.keyNumberGlobal, _("Direct menu item selection")),
+			"4": (self.keyNumberGlobal, _("Direct menu item selection")),
+			"5": (self.keyNumberGlobal, _("Direct menu item selection")),
+			"6": (self.keyNumberGlobal, _("Direct menu item selection")),
+			"7": (self.keyNumberGlobal, _("Direct menu item selection")),
+			"8": (self.keyNumberGlobal, _("Direct menu item selection")),
+			"9": (self.keyNumberGlobal, _("Direct menu item selection")),
+			"0": (self.keyNumberGlobal, _("Direct menu item selection"))
+		}, prio=0, description=_("Common Menu Actions"))
 
 		a = parent.get("title", "").encode("UTF-8") or None
 		a = a and _(a) or _(parent.get("text", "").encode("UTF-8"))

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -69,6 +69,30 @@ class MenuSummary(ScreenSummary):
 
 class Menu(Screen, HelpableScreen, ProtectedScreen):
 	ALLOW_SUSPEND = True
+	skin = ["""
+	<screen name="Menu" position="center,center" size="%d,%d">
+		<widget source="menu" render="Listbox" position="%d,%d" size="e-%d,%d" enableWrapAround="1" scrollbarMode="showOnDemand">
+			<convert type="TemplatedMultiContent">
+				{
+				"template":
+					[
+					MultiContentEntryText(pos = (%d, 0), size = (%d, %d), font = 0, flags = RT_HALIGN_LEFT | RT_VALIGN_CENTER, text = 0)
+					],
+				"fonts": [parseFont("Regular;%d")],
+				"itemHeight": %d
+				}
+			</convert>
+		</widget>
+		<widget source="key_help" render="Label" position="e-%d,e-%d" size="%d,%d" backgroundColor="key_back" font="Regular;%d" foregroundColor="key_text" halign="center" valign="center">
+			<convert type="ConditionalShowHide" />
+		</widget>
+		<widget name="menuimage" position="0,0" size="0,0" alphatest="blend" conditional="menuimage" transparent="1" />
+	</screen>""",
+		800, 560,  # screen
+		10, 10, 20, 490,  # menu
+		20, 740, 35, 25, 35,  # template
+		90, 50, 80, 40, 20  # key_help
+	]
 
 	def okbuttonClick(self):
 		if self.number:
@@ -205,7 +229,7 @@ class Menu(Screen, HelpableScreen, ProtectedScreen):
 
 
 	def __init__(self, session, parent):
-		Screen.__init__(self, session)
+		Screen.__init__(self, session, mandatoryWidgets=["menu"])
 		HelpableScreen.__init__(self)
 		list = []
 


### PR DESCRIPTION
[Menu.py] Update summary screen
- Use new ScreenSummary base class.
- Add "entry" widget to to be used by newer display screens.

[Menu.py] Add help to menus
- Add help to all menus displayed by Menu.py.
- Move the "closeRecursive()" action from the MENU button to the long EXIT button like in Setup and many ConfigList based screens.

[Menu.py] Add embedded scalable screen skin
- Add embedded scalable screen skin using the new core skin scaling system.
