### PR TITLE
More keymap improvements

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -34,6 +34,18 @@
 		undesirable side effects.
 	-->
 
+	<map context="CancelSaveActions">
+		<key id="KEY_RED" mapto="cancel" flags="m" />
+		<key id="KEY_GREEN" mapto="save" flags="m" />
+		<key id="KEY_EXIT" mapto="cancel" flags="b" />
+		<key id="KEY_EXIT" mapto="close" flags="l" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_F5" mapto="cancel" flags="m" />
+		<key id="KEY_F6" mapto="save" flags="m" />
+		<key id="KEY_ESC" mapto="cancel" flags="b" />
+		<key id="KEY_ESC" mapto="close" flags="l" />
+	</map>
+
 	<map context="ColorActions">
 		<key id="KEY_RED" mapto="red" flags="b" />
 		<key id="KEY_RED" mapto="redlong" flags="l" />
@@ -43,12 +55,55 @@
 		<key id="KEY_YELLOW" mapto="yellowlong" flags="l" />
 		<key id="KEY_BLUE" mapto="blue" flags="b" />
 		<key id="KEY_BLUE" mapto="bluelong" flags="l" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_F5" mapto="red" flags="b" />
+		<key id="KEY_F5" mapto="redlong" flags="l" />
+		<key id="KEY_F6" mapto="green" flags="b" />
+		<key id="KEY_F6" mapto="greenlong" flags="l" />
+		<key id="KEY_F7" mapto="yellow" flags="b" />
+		<key id="KEY_F7" mapto="yellowlong" flags="l" />
+		<key id="KEY_F8" mapto="blue" flags="b" />
+		<key id="KEY_F8" mapto="bluelong" flags="l" />
+	</map>
+
+	<map context="ColorActionsNew">
+		<key id="KEY_RED" mapto="red" flags="m" />
+		<key id="KEY_RED" mapto="RED" flags="b" />
+		<key id="KEY_RED" mapto="redLong" flags="l" />
+		<key id="KEY_GREEN" mapto="green" flags="m" />
+		<key id="KEY_GREEN" mapto="GREEN" flags="b" />
+		<key id="KEY_GREEN" mapto="greenLong" flags="l" />
+		<key id="KEY_YELLOW" mapto="yellow" flags="m" />
+		<key id="KEY_YELLOW" mapto="YELLOW" flags="b" />
+		<key id="KEY_YELLOW" mapto="yellowLong" flags="l" />
+		<key id="KEY_BLUE" mapto="blue" flags="m" />
+		<key id="KEY_BLUE" mapto="BLUE" flags="b" />
+		<key id="KEY_BLUE" mapto="blueLong" flags="l" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_F5" mapto="red" flags="m" />
+		<key id="KEY_F5" mapto="RED" flags="b" />
+		<key id="KEY_F5" mapto="redLong" flags="l" />
+		<key id="KEY_F6" mapto="green" flags="m" />
+		<key id="KEY_F6" mapto="GREEN" flags="b" />
+		<key id="KEY_F6" mapto="greenLong" flags="l" />
+		<key id="KEY_F7" mapto="yellow" flags="m" />
+		<key id="KEY_F7" mapto="YELLOW" flags="b" />
+		<key id="KEY_F7" mapto="yellowLong" flags="l" />
+		<key id="KEY_F8" mapto="blue" flags="m" />
+		<key id="KEY_F8" mapto="BLUE" flags="b" />
+		<key id="KEY_F8" mapto="blueLong" flags="l" />
 	</map>
 
 	<map context="HelpActions">
+		<!-- <key id="KEY_HELP" mapto="displayHelp" flags="m" /> -->
+		<!-- <key id="KEY_HELP" mapto="DISPLAYHELP" flags="b" /> -->
 		<key id="KEY_HELP" mapto="displayHelp" flags="b" />
+		<key id="KEY_HELP" mapto="displayHelpLong" flags="l" />
 		<!-- Keyboard specific buttons -->
+		<!-- <key id="KEY_F1" mapto="displayHelp" flags="m" /> -->
+		<!-- <key id="KEY_F1" mapto="DISPLAYHELP" flags="b" /> -->
 		<key id="KEY_F1" mapto="displayHelp" flags="b" />
+		<key id="KEY_F1" mapto="displayHelpLong" flags="l" />
 	</map>
 
 	<map context="InputAsciiActions">
@@ -57,7 +112,18 @@
 
 	<map context="MenuActions">
 		<key id="KEY_MENU" mapto="menu" flags="mr" />
+		<!-- Keyboard specific buttons -->
 		<key id="KEY_SPACE" mapto="menu" flags="mr" />
+	</map>
+
+	<map context="MenuActionsNew">
+		<key id="KEY_MENU" mapto="menu" flags="m" />
+		<key id="KEY_MENU" mapto="MENU" flags="b" />
+		<key id="KEY_MENU" mapto="menuLong" flags="l" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_SPACE" mapto="menu" flags="m" />
+		<key id="KEY_SPACE" mapto="MENU" flags="b" />
+		<key id="KEY_SPACE" mapto="menuLong" flags="l" />
 	</map>
 
 	<map context="NavigationActions">
@@ -106,19 +172,31 @@
 		<key id="KEY_KP9" mapto="9" flags="m" />
 	</map>
 
+	<map context="OkActions">
+		<key id="KEY_OK" mapto="ok" flags="m" />
+		<key id="KEY_OK" mapto="OK" flags="b" />
+		<key id="KEY_OK" mapto="okLong" flags="l" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_ENTER" mapto="ok" flags="m" />
+		<key id="KEY_ENTER" mapto="OK" flags="b" />
+		<key id="KEY_ENTER" mapto="okLong" flags="l" />
+	</map>
+
 	<map context="OkCancelActions">
 		<key id="KEY_OK" mapto="ok" flags="m" />
 		<key id="KEY_OK" mapto="OK" flags="b" />
 		<key id="KEY_OK" mapto="OKLong" flags="l" />
-		<key id="KEY_EXIT" mapto="cancel" flags="m" />
+		<!-- <key id="KEY_EXIT" mapto="cancel" flags="m" /> -->
 		<!-- <key id="KEY_EXIT" mapto="CANCEL" flags="b" /> -->
-		<!-- <key id="KEY_EXIT" mapto="close" flags="l" /> -->
+		<key id="KEY_EXIT" mapto="cancel" flags="b" />
+		<key id="KEY_EXIT" mapto="close" flags="l" />
 		<!-- Keyboard specific buttons -->
 		<key id="KEY_ENTER" mapto="ok" flags="m" />
 		<key id="KEY_ENTER" mapto="OK" flags="b" />
 		<key id="KEY_ENTER" mapto="OKLong" flags="l" />
-		<key id="KEY_ESC" mapto="cancel" flags="m" />
-		<key id="KEY_ESC" mapto="CANCEL" flags="b" />
+		<!-- <key id="KEY_ESC" mapto="cancel" flags="m" /> -->
+		<!-- <key id="KEY_ESC" mapto="CANCEL" flags="b" /> -->
+		<key id="KEY_ESC" mapto="cancel" flags="b" />
 		<key id="KEY_ESC" mapto="close" flags="l" />
 		<key id="\x0a" mapto="ok" flags="m" />
 		<key id="\x1b" mapto="cancel" flags="m" />

--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -34,10 +34,30 @@
 		undesirable side effects.
 	-->
 
+	<map context="ColorActions">
+		<key id="KEY_RED" mapto="red" flags="b" />
+		<key id="KEY_RED" mapto="redlong" flags="l" />
+		<key id="KEY_GREEN" mapto="green" flags="b" />
+		<key id="KEY_GREEN" mapto="greenlong" flags="l" />
+		<key id="KEY_YELLOW" mapto="yellow" flags="b" />
+		<key id="KEY_YELLOW" mapto="yellowlong" flags="l" />
+		<key id="KEY_BLUE" mapto="blue" flags="b" />
+		<key id="KEY_BLUE" mapto="bluelong" flags="l" />
+	</map>
+
 	<map context="HelpActions">
 		<key id="KEY_HELP" mapto="displayHelp" flags="b" />
 		<!-- Keyboard specific buttons -->
 		<key id="KEY_F1" mapto="displayHelp" flags="b" />
+	</map>
+
+	<map context="InputAsciiActions">
+		<key id="KEY_ASCII" mapto="gotAsciiCode" flags="mr" />
+	</map>
+
+	<map context="MenuActions">
+		<key id="KEY_MENU" mapto="menu" flags="mr" />
+		<key id="KEY_SPACE" mapto="menu" flags="mr" />
 	</map>
 
 	<map context="NavigationActions">
@@ -84,6 +104,24 @@
 		<key id="KEY_KP7" mapto="7" flags="m" />
 		<key id="KEY_KP8" mapto="8" flags="m" />
 		<key id="KEY_KP9" mapto="9" flags="m" />
+	</map>
+
+	<map context="OkCancelActions">
+		<key id="KEY_OK" mapto="ok" flags="m" />
+		<key id="KEY_OK" mapto="OK" flags="b" />
+		<key id="KEY_OK" mapto="OKLong" flags="l" />
+		<key id="KEY_EXIT" mapto="cancel" flags="m" />
+		<!-- <key id="KEY_EXIT" mapto="CANCEL" flags="b" /> -->
+		<!-- <key id="KEY_EXIT" mapto="close" flags="l" /> -->
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_ENTER" mapto="ok" flags="m" />
+		<key id="KEY_ENTER" mapto="OK" flags="b" />
+		<key id="KEY_ENTER" mapto="OKLong" flags="l" />
+		<key id="KEY_ESC" mapto="cancel" flags="m" />
+		<key id="KEY_ESC" mapto="CANCEL" flags="b" />
+		<key id="KEY_ESC" mapto="close" flags="l" />
+		<key id="\x0a" mapto="ok" flags="m" />
+		<key id="\x1b" mapto="cancel" flags="m" />
 	</map>
 
 	<map context="TextEditActions">
@@ -407,10 +445,6 @@
 		<key id="KEY_ESC" mapto="cancel" flags="m" />
 	</map>
 
-	<map context="InputAsciiActions">
-		<key id="KEY_ASCII" mapto="gotAsciiCode" flags="mr" />
-	</map>
-
 	<map context="InputBoxActions">
 		<key id="KEY_LEFT" mapto="left" flags="mr" />
 		<key id="KEY_RIGHT" mapto="right" flags="mr" />
@@ -452,11 +486,6 @@
 		<key id="KEY_OPTION" mapto="showNetworkSetup" flags="mr" />
 		<key id="KEY_F5" mapto="showRFmod" flags="b" />
 		<key id="KEY_F5" mapto="toggleAspectRatio" flags="l" />
-	</map>
-
-	<map context="MenuActions">
-		<key id="KEY_MENU" mapto="menu" flags="mr" />
-		<key id="KEY_SPACE" mapto="menu" flags="mr" />
 	</map>
 
 	<map context="InfobarShowHideActions">
@@ -875,24 +904,6 @@
 		<key id="KEY_EPG" mapto="openSingleServiceEPG" flags="m" />
 	</map>
 
-	<map context="OkCancelActions">
-		<key id="KEY_OK" mapto="ok" flags="m" />
-		<key id="KEY_OK" mapto="OK" flags="b" />
-		<key id="KEY_OK" mapto="OKLong" flags="l" />
-		<key id="KEY_EXIT" mapto="cancel" flags="m" />
-		<!-- <key id="KEY_EXIT" mapto="CANCEL" flags="b" /> -->
-		<!-- <key id="KEY_EXIT" mapto="close" flags="l" /> -->
-		<!-- Keyboard specific buttons -->
-		<key id="KEY_ENTER" mapto="ok" flags="m" />
-		<key id="KEY_ENTER" mapto="OK" flags="b" />
-		<key id="KEY_ENTER" mapto="OKLong" flags="l" />
-		<key id="KEY_ESC" mapto="cancel" flags="m" />
-		<key id="KEY_ESC" mapto="CANCEL" flags="b" />
-		<key id="KEY_ESC" mapto="close" flags="l" />
-		<key id="\x0a" mapto="ok" flags="m" />
-		<key id="\x1b" mapto="cancel" flags="m" />
-	</map>
-
 	<map context="DirectionActions">
 		<key id="KEY_UP" mapto="up" flags="mr" />
 		<key id="KEY_DOWN" mapto="down" flags="mr" />
@@ -900,17 +911,6 @@
 		<key id="KEY_RIGHT" mapto="right" flags="mr" />
 		<key id="KEY_PREVIOUS" mapto="shiftUp" flags="m" />
 		<key id="KEY_NEXT" mapto="shiftDown" flags="m" />
-	</map>
-
-	<map context="ColorActions">
-		<key id="KEY_RED" mapto="red" flags="b" />
-		<key id="KEY_RED" mapto="redlong" flags="l" />
-		<key id="KEY_GREEN" mapto="green" flags="b" />
-		<key id="KEY_GREEN" mapto="greenlong" flags="l" />
-		<key id="KEY_YELLOW" mapto="yellow" flags="b" />
-		<key id="KEY_YELLOW" mapto="yellowlong" flags="l" />
-		<key id="KEY_BLUE" mapto="blue" flags="b" />
-		<key id="KEY_BLUE" mapto="bluelong" flags="l" />
 	</map>
 
 	<map context="FunctionKeyActions">


### PR DESCRIPTION
[keymap.xml] Move more shared key maps to shared area
- Move more shared key maps to shared area in alphabetical order.

[keymap.xml] Add more comments and key map options
- Add new "CancelSaveActions" element.
- Add keyboard options for "ColorActions".
- Add placeholders in "HelpActions" for more event types.
- Add new "OkActions" element.
- Add placeholders in "OkCancelActions" for more event types.
- Change "OkCancelActions" "KEY_EXIT" and "KEY_ESC" from a make event to a break event and add a long event.  This allows EXIT (and ESC) to trigger a "cancel" action on a short press and a "close" action on a long press.
- Add new "ColorActionsNew" and "ColorActionsNew" elements as discussion points for developers to review using the expanded structures to allow different code and images to share the proposed key maps and allow separate and controllable access to all of the "Make", "Break" and "Long" events in a single key map.
