### PR TITLE
More ConfigList improvements

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -209,12 +209,17 @@ class ConfigListScreen:
 		self["config"] = ConfigList(list, session=session)
 		self.setCancelMessage(None)
 		self.onChangedEntry = []
+		if self.noNativeKeys not in self.onLayoutFinish:
+			self.onLayoutFinish.append(self.noNativeKeys)
 		if self.handleInputHelpers not in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.handleInputHelpers)
 		if self.showHelpWindow not in self.onExecBegin:
 			self.onExecBegin.append(self.showHelpWindow)
 		if self.hideHelpWindow not in self.onExecEnd:
 			self.onExecEnd.append(self.hideHelpWindow)
+
+	def noNativeKeys(self):
+		self["config"].instance.allowNativeKeys(False)
 
 	def setCancelMessage(self, msg):
 		self.cancelMsg = _("Really close without saving settings?") if msg is None else msg

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -288,8 +288,12 @@ class ConfigListScreen:
 				self.entryChanged()
 
 	def keySelect(self):
-		if isinstance(self.getCurrentItem(), ConfigSelection):
+		if isinstance(self.getCurrentItem(), ConfigBoolean):
+			self.keyRight()
+		elif isinstance(self.getCurrentItem(), ConfigSelection):
 			self.keyMenu()
+		elif isinstance(self.getCurrentItem(), ConfigText):
+			self.keyText()
 		else:
 			self["config"].handleKey(KEYA_SELECT)
 

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -155,7 +155,7 @@ class ConfigListScreen:
 				"cancel": (self.keyCancel, _("Cancel any changed settings and exit")),
 				"close": (self.closeRecursive, _("Cancel any changed settings and exit all menus")),
 				"save": (self.keySave, _("Save all changed settings and exit"))
-			}, prio=1, description=_("Common Setup Functions"))
+			}, prio=1, description=_("Common Setup Actions"))
 		if "key_menu" not in self:
 			self["key_menu"] = StaticText(_("MENU"))
 		if "HelpWindow" not in self:
@@ -165,7 +165,7 @@ class ConfigListScreen:
 			self["VKeyIcon"] = Boolean(False)
 		self["configActions"] = HelpableActionMap(self, ["ConfigListActions"], {
 			"select": (self.keySelect, _("Select, toggle, process or edit the current entry"))
-		}, prio=1, description=_("Common Setup Functions"))
+		}, prio=1, description=_("Common Setup Actions"))
 		self["navigationActions"] = HelpableActionMap(self, ["NavigationActions"], {
 			"top": (self.keyTop, _("Move to first line")),
 			"pageUp": (self.keyPageUp, _("Move up a screen")),
@@ -177,14 +177,14 @@ class ConfigListScreen:
 			"down": (self.keyDown, _("Move down a line")),
 			"pageDown": (self.keyPageDown, _("Move down a screen")),
 			"bottom": (self.keyBottom, _("Move to last line"))
-		}, prio=1, description=_("Common Setup Functions"))
+		}, prio=1, description=_("Common Setup Actions"))
 		self["menuConfigActions"] = HelpableActionMap(self, "ConfigListActions", {
 			"menu": (self.keyMenu, _("Display selection list as a selection menu")),
-		}, prio=1, description=_("Common Setup Functions"))
+		}, prio=1, description=_("Common Setup Actions"))
 		self["menuConfigActions"].setEnabled(False)
 		self["editConfigActions"] = HelpableNumberActionMap(self, ["NumberActions", "TextEditActions"], {
-			"backspace": (self.keyBackspace, _("Delete the character to the left of cursor")),
-			"delete": (self.keyDelete, _("Delete the character under the cursor")),
+			"backspace": (self.keyBackspace, _("Delete character to left of cursor or select AM times")),
+			"delete": (self.keyDelete, _("Delete character under cursor or select PM times")),
 			"erase": (self.keyErase, _("Delete all the text")),
 			"toggleOverwrite": (self.keyToggleOW, _("Toggle new text inserts before or overwrites existing text")),
 			"1": (self.keyNumberGlobal, _("Number or SMS style data entry")),
@@ -198,11 +198,11 @@ class ConfigListScreen:
 			"9": (self.keyNumberGlobal, _("Number or SMS style data entry")),
 			"0": (self.keyNumberGlobal, _("Number or SMS style data entry")),
 			"gotAsciiCode": (self.keyGotAscii, _("Keyboard data entry"))
-		}, prio=1, description=_("Common Setup Functions"))
+		}, prio=1, description=_("Common Setup Actions"))
 		self["editConfigActions"].setEnabled(False)
 		self["VirtualKB"] = HelpableActionMap(self, "VirtualKeyboardActions", {
 			"showVirtualKeyboard": (self.keyText, _("Display the virtual keyboard for data entry"))
-		}, prio=1, description=_("Common Setup Functions"))
+		}, prio=1, description=_("Common Setup Actions"))
 		self["VirtualKB"].setEnabled(False)
 		self["config"] = ConfigList(list, session=session)
 		self.setCancelMessage(None)

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -164,7 +164,6 @@ class ConfigListScreen:
 		if "VKeyIcon" not in self:
 			self["VKeyIcon"] = Boolean(False)
 		self["configActions"] = HelpableActionMap(self, ["ConfigListActions"], {
-			"ok": (self.keySelect, _("Select, toggle, process or edit the current entry")),
 			"select": (self.keySelect, _("Select, toggle, process or edit the current entry"))
 		}, prio=1, description=_("Common Setup Functions"))
 		self["menuConfigActions"] = HelpableActionMap(self, "ConfigListActions", {

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -166,24 +166,22 @@ class ConfigListScreen:
 		self["configActions"] = HelpableActionMap(self, ["ConfigListActions"], {
 			"select": (self.keySelect, _("Select, toggle, process or edit the current entry"))
 		}, prio=1, description=_("Common Setup Functions"))
+		self["navigationActions"] = HelpableActionMap(self, ["NavigationActions"], {
+			"top": (self.keyTop, _("Move to first line")),
+			"pageUp": (self.keyPageUp, _("Move up a screen")),
+			"up": (self.keyUp, _("Move up a line")),
+			"first": (self.keyFirst, _("Jump to first item in list or the start of text")),
+			"left": (self.keyLeft, _("Select the previous item in list or move cursor left")),
+			"right": (self.keyRight, _("Select the next item in list or move cursor right")),
+			"last": (self.keyLast, _("Jump to last item in list or the end of text")),
+			"down": (self.keyDown, _("Move down a line")),
+			"pageDown": (self.keyPageDown, _("Move down a screen")),
+			"bottom": (self.keyBottom, _("Move to last line"))
+		}, prio=1, description=_("Common Setup Functions"))
 		self["menuConfigActions"] = HelpableActionMap(self, "ConfigListActions", {
 			"menu": (self.keyMenu, _("Display selection list as a selection menu")),
 		}, prio=1, description=_("Common Setup Functions"))
 		self["menuConfigActions"].setEnabled(False)
-		self["directionActions"] = HelpableActionMap(self, ["NavigationActions"], {
-			"pageDown": (self.keyPageDown, _("Move down a screen")),
-			"first": (self.keyFirst, _("Jump to first item in list or the start of text")),
-			"last": (self.keyLast, _("Jump to last item in list or the end of text")),
-			"pageUp": (self.keyPageUp, _("Move up a screen"))
-		}, prio=1, description=_("Common Setup Functions"))
-		self["navigationActions"] = HelpableActionMap(self, ["NavigationActions"], {
-			"top": (self.keyTop, _("Move to first line")),
-			"up": (self.keyUp, _("Move up a line")),
-			"left": (self.keyLeft, _("Select the previous item in list or move cursor left")),
-			"right": (self.keyRight, _("Select the next item in list or move cursor right")),
-			"down": (self.keyDown, _("Move down a line")),
-			"bottom": (self.keyBottom, _("Move to last line"))
-		}, prio=-1, description=_("Common Setup Functions"))  # The priority is set to -1 to override the internal list box navigation controls.
 		self["editConfigActions"] = HelpableNumberActionMap(self, ["NumberActions", "TextEditActions"], {
 			"backspace": (self.keyBackspace, _("Delete the character to the left of cursor")),
 			"delete": (self.keyDelete, _("Delete the character under the cursor")),

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -390,19 +390,19 @@ class ConfigListScreen:
 	def closeRecursive(self):
 		self.closeConfigList((True,))
 
-	def closeConfigList(self, recursiveClose=()):
+	def closeConfigList(self, closeParameters=()):
 		if self["config"].isChanged():
-			self.recursiveClose = recursiveClose
+			self.closeParameters = closeParameters
 			self.session.openWithCallback(self.cancelConfirm, MessageBox, self.cancelMsg, default=False, type=MessageBox.TYPE_YESNO)
 		else:
-			self.close(*recursiveClose)
+			self.close(*closeParameters)
 
 	def cancelConfirm(self, result):
 		if not result:
 			return
 		for x in self["config"].list:
 			x[1].cancel()
-		self.close(*self.recursiveClose)
+		self.close(*self.closeParameters)
 
 	def createSummary(self):  # This should not be required if ConfigList is invoked via Setup (as it should).
 		from Screens.Setup import SetupSummary

--- a/lib/python/Screens/FactoryReset.py
+++ b/lib/python/Screens/FactoryReset.py
@@ -168,11 +168,5 @@ class FactoryReset(Setup, ProtectedScreen):
 				if err.errno != errno.ENOENT:
 					print("[FactoryReset] Error: Unable to delete '%s'!  (%s)" % (target, str(err)))
 
-	def keyCancel(self):  # Old Setup close key method.
-		self.closeConfigList(recursiveClose=False)
-
-	def closeRecursive(self):  # Old Setup close recursive key method.
-		self.closeConfigList(recursiveClose=True)
-
-	def closeConfigList(self, recursiveClose=False):
-		self.close(recursiveClose)
+	def closeConfigList(self, closeParameters=()):
+		self.close(*closeParameters)


### PR DESCRIPTION
[ConfigList.py] Remove redundant "ok" action

[ConfigList.py] Rename "recursiveClose" to "closeParameters"
- Prl suggested that this is a more useful name as the parameter may not always relate to a recursive close.

[ConfigList.py] Enhance the keySelect() method
- Add new functions for the "select" action (typically the OK button) to trigger the VirtualKeyBoard on any ConfigText based elements and toggle the value of any ConfigBoolean elements.

[ConfigList.py] Enable "allowNativeKeys()"
- This change uses the new list "allowNativeKeys()" method to disable the native binding of direction remote control keys to the list control at the C++ layer.  This returns full control of all remote control buttons back to the Python code layer.

    When this method is used the coder must provide Python code for *ALL* list navigation functions at the Python layer.

[ConfigList.py] Simplify the action maps
- Now that the "allowNativeKeys()" method is available the action maps can be unified and simplified.

[ConfigList.py] Improve the action map language

[FactoryReset.py] Adjust for updated ConfigList.py
- This change applies the ConfigList.py change from "recursiveClose" to "closeParameters".
