### PR TITLE
Refactor Recordings.py

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -174,7 +174,10 @@
 		<item level="1" text="EPG language selection 1" description="Configure the primary EPG language.">config.autolanguage.audio_epglanguage</item>
 		<item level="1" text="EPG language selection 2" conditional="config.autolanguage.audio_epglanguage.value" description="Configure the secondary EPG language.">config.autolanguage.audio_epglanguage_alternative</item>
 	</setup>
-	<setup key="recording" title="Recording and playback">
+	<setup key="Recording" title="Recording and playback">
+		<item level="0" text="Default movie location" description="Set the default location for your recordings. Press OK to add new locations, LEFT/RIGHT to select from any existing locations.">config.usage.default_path</item>
+		<item level="2" text="Timer recording location" description="Set the default location for your timers. Press OK to add new locations, LEFT/RIGHT to select from any existing locations.">config.usage.timer_path</item>
+		<item level="2" text="Instant recording location" description="Set the default location for your instant recordings. Press OK to add new locations, LEFT/RIGHT to select from any existing locations.">config.usage.instantrec_path</item>
 <!--		<item level="2" text="Preferred tuner for recordings" description="Configure which tuner will be preferred for recordings, when more than one tuner is available. 'Disabled' would select a tuner based on preferred tuner in customise screen. 'Auto' would choose based on E2's default rules, ignoring preferred tuner in customise screen.">config.usage.recording_frontend_priority</item>-->
 		<item level="1" text="Recordings always have priority" description="When enabled, a recording is allowed to interrupt live TV, when there are no free tuners.">config.recording.asktozap</item>
 		<item level="0" text="Margin before recording (minutes)" description="When nonzero, a recording will start earlier than the starting time indicated by the EPG.">config.recording.margin_before</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -140,24 +140,19 @@ def InitUsageConfig():
 
 	if not os.path.exists(resolveFilename(SCOPE_HDD)):
 		try:
-			os.mkdir(resolveFilename(SCOPE_HDD),0755)
-		except:
+			os.mkdir(resolveFilename(SCOPE_HDD), 0755)
+		except (IOError, OSError):
 			pass
-	config.usage.default_path = ConfigText(default = resolveFilename(SCOPE_HDD))
-	if not config.usage.default_path.value.endswith('/'):
-		tmpvalue = config.usage.default_path.value
-		config.usage.default_path.setValue(tmpvalue + '/')
-		config.usage.default_path.save()
-	def defaultpathChanged(configElement):
-		if not config.usage.default_path.value.endswith('/'):
-			tmpvalue = config.usage.default_path.value
-			config.usage.default_path.setValue(tmpvalue + '/')
-			config.usage.default_path.save()
-	config.usage.default_path.addNotifier(defaultpathChanged, immediate_feedback = False)
-
-	config.usage.timer_path = ConfigText(default = "<default>")
-	config.usage.instantrec_path = ConfigText(default = "<default>")
-
+	defaultValue = resolveFilename(SCOPE_HDD)
+	config.usage.default_path = ConfigSelection(default=defaultValue, choices=[(defaultValue, defaultValue)])
+	config.usage.default_path.load()
+	if config.usage.default_path.saved_value:
+		savedValue = os.path.join(config.usage.default_path.saved_value, "")
+		if savedValue and savedValue != defaultValue:
+			config.usage.default_path.setChoices([(defaultValue, defaultValue), (savedValue, savedValue)], default=defaultValue)
+	config.usage.default_path.save()
+	config.usage.timer_path = ConfigSelection(default="<default>", choices=[("<default>", "<default>")])
+	config.usage.instantrec_path = ConfigSelection(default="<default>", choices=[("<default>", "<default>")])
 	if not os.path.exists(resolveFilename(SCOPE_TIMESHIFT)):
 		try:
 			os.mkdir(resolveFilename(SCOPE_TIMESHIFT),0755)

--- a/lib/python/Screens/Recordings.py
+++ b/lib/python/Screens/Recordings.py
@@ -1,261 +1,103 @@
-from Screens.Screen import Screen
-from Screens.Setup import setupdom
-from Screens.LocationBox import MovieLocationBox
-from Screens.MessageBox import MessageBox
-from Components.Label import Label
-from Components.config import config, configfile, ConfigNothing, ConfigSelection, getConfigListEntry
-from Components.ConfigList import ConfigListScreen
-from Components.ActionMap import ActionMap
-from Components.Pixmap import Pixmap
-from Tools.Directories import fileExists
+from os import stat
+from os.path import isdir, join as pathJoin
+
+from Components.config import config
 from Components.UsageConfig import preferredPath
-#from Components.Sources.Boolean import Boolean
-from Components.Sources.StaticText import StaticText
-from Components.SystemInfo import SystemInfo
+from Screens.LocationBox import defaultInhibitDirs, MovieLocationBox
+from Screens.MessageBox import MessageBox
+from Screens.Setup import Setup
+from Tools.Directories import fileExists
 
 
-class SetupSummary(Screen):
-	def __init__(self, session, parent):
-		Screen.__init__(self, session, parent = parent)
-		self["SetupTitle"] = StaticText(parent.getTitle())
-		self["SetupEntry"] = StaticText("")
-		self["SetupValue"] = StaticText("")
-		self.onShow.append(self.addWatcher)
-		self.onHide.append(self.removeWatcher)
+class RecordingSettings(Setup):
+	def __init__(self, session):
+		self.styles = [("<default>", _("<Default movie location>")), ("<current>", _("<Current movielist location>")), ("<timer>", _("<Last timer location>"))]
+		self.styleKeys = [x[0] for x in self.styles]
+		self.inhibitDevs = []
+		for dir in defaultInhibitDirs + ["/", "/media"]:
+			if isdir(dir):
+				device = stat(dir).st_dev
+				if device not in self.inhibitDevs:
+					self.inhibitDevs.append(device)
+		self.buildChoices("DefaultPath", config.usage.default_path, None)
+		self.buildChoices("TimerPath", config.usage.timer_path, None)
+		self.buildChoices("InstantPath", config.usage.instantrec_path, None)
+		Setup.__init__(self, session=session, setup="Recording")
+		self.greenText = self["key_green"].text
+		self.errorItem = -1
+		if self.getCurrentItem() in (config.usage.default_path, config.usage.timer_path, config.usage.instantrec_path):
+			self.pathStatus(self.getCurrentValue())
 
-	def addWatcher(self):
-		self.parent.onChangedEntry.append(self.selectionChanged)
-		self.parent["config"].onSelectionChanged.append(self.selectionChanged)
-		self.selectionChanged()
+	def buildChoices(self, item, configEntry, path):
+		configList = config.movielist.videodirs.value[:]
+		styleList = [] if item == "DefaultPath"	else self.styleKeys
+		if configEntry.saved_value and configEntry.saved_value not in styleList + configList:
+			configList.append(configEntry.saved_value)
+			configEntry.value = configEntry.saved_value
+		if path is None:
+			path = configEntry.value
+		if path and path not in styleList + configList:
+			configList.append(path)
+		pathList = [(x, x) for x in configList] if item == "DefaultPath" else self.styles + [(x, x) for x in configList]
+		configEntry.value = path
+		configEntry.setChoices(pathList, default=configEntry.default)
+		# print("[Recordings] DEBUG %s: Current='%s', Default='%s', Choices='%s'." % (item, configEntry.value, configEntry.default, styleList + configList))
 
-	def removeWatcher(self):
-		self.parent.onChangedEntry.remove(self.selectionChanged)
-		self.parent["config"].onSelectionChanged.remove(self.selectionChanged)
+	def pathSelect(self, path):
+		if path is not None:
+			path = pathJoin(path, "")
+			item = self.getCurrentItem()
+			if item is config.usage.default_path:
+				self.buildChoices("DefaultPath", config.usage.default_path, path)
+			else:
+				self.buildChoices("DefaultPath", config.usage.default_path, None)
+			if item is config.usage.timer_path:
+				self.buildChoices("TimerPath", config.usage.timer_path, path)
+			else:
+				self.buildChoices("TimerPath", config.usage.timer_path, None)
+			if item is config.usage.instantrec_path:
+				self.buildChoices("InstantPath", config.usage.instantrec_path, path)
+			else:
+				self.buildChoices("InstantPath", config.usage.instantrec_path, None)
+		self["config"].invalidateCurrent()
+		self.changedEntry()
+
+	def pathStatus(self, path):
+		self.errorItem = -1
+		self.setFootnote("")
+		self["key_green"].text = self.greenText
+		if not path.startswith("<"):
+			filedevice = stat(path).st_dev
+			if filedevice in self.inhibitDevs:
+				self.errorItem = self["config"].getCurrentIndex()
+				self.setFootnote(_("Flash directory '%s' not allowed!") % path)
+				self["key_green"].text = ""
+			elif not fileExists(path, "w"):
+				self.errorItem = self["config"].getCurrentIndex()
+				self.setFootnote(_("Directory '%s' not writable!") % path)
+				self["key_green"].text = ""
 
 	def selectionChanged(self):
-		self["SetupEntry"].text = self.parent.getCurrentEntry()
-		self["SetupValue"].text = self.parent.getCurrentValue()
-		if hasattr(self.parent,"getCurrentDescription"):
-			self.parent["description"].text = self.parent.getCurrentDescription()
-		if self.parent.has_key('footnote'):
-			if self.parent.getCurrentEntry().endswith('*'):
-				self.parent['footnote'].text = (_("* = Restart Required"))
-			else:
-				self.parent['footnote'].text = ("")
-
-class RecordingSettings(Screen,ConfigListScreen):
-	def removeNotifier(self):
-		config.usage.setup_level.notifiers.remove(self.levelChanged)
-
-	def levelChanged(self, configElement):
-		list = []
-		self.refill(list)
-		self["config"].setList(list)
-
-	def refill(self, list):
-		xmldata = setupdom().getroot()
-		for x in xmldata.findall("setup"):
-			if x.get("key") != self.setup:
-				continue
-			self.addItems(list, x)
-			self.title = _(x.get("title", "Setup").encode("UTF-8"))
-			self.seperation = int(x.get('separation', '0'))
-
-	def __init__(self, session):
-		Screen.__init__(self, session)
-		self.skinName = "Setup"
-		self['footnote'] = Label()
-
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
-		self["description"] = Label("")
-
-		self.onChangedEntry = [ ]
-		self.setup = "recording"
-		list = []
-		ConfigListScreen.__init__(self, list, session = session, on_change = self.changedEntry)
-		self.createSetup()
-
-		self["setupActions"] = ActionMap(["SetupActions", "ColorActions", "MenuActions"],
-		{
-			"green": self.keySave,
-			"red": self.keyCancel,
-			"cancel": self.keyCancel,
-			"ok": self.ok,
-			"menu": self.closeRecursive,
-		}, -2)
-
-	def checkReadWriteDir(self, configele):
-# 		print "checkReadWrite: ", configele.value
-		if configele.value in [x[0] for x in self.styles] or fileExists(configele.value, "w"):
-			configele.last_value = configele.value
-			return True
+		if self.errorItem == -1:
+			Setup.selectionChanged(self)
 		else:
-			dir = configele.value
-			configele.value = configele.last_value
-			self.session.open(
-				MessageBox,
-				_("The directory %s is not writable.\nMake sure you select a writable directory instead.")%dir,
-				type = MessageBox.TYPE_ERROR
-				)
-			return False
-
-	def createSetup(self):
-		self.styles = [ ("<default>", _("<Default movie location>")), ("<current>", _("<Current movielist location>")), ("<timer>", _("<Last timer location>")) ]
-		styles_keys = [x[0] for x in self.styles]
-		tmp = config.movielist.videodirs.value
-		default = config.usage.default_path.value
-		if default not in tmp:
-			tmp = tmp[:]
-			tmp.append(default)
-# 		print "DefaultPath: ", default, tmp
-		self.default_dirname = ConfigSelection(default = default, choices = tmp)
-		tmp = config.movielist.videodirs.value
-		default = config.usage.timer_path.value
-		if default not in tmp and default not in styles_keys:
-			tmp = tmp[:]
-			tmp.append(default)
-# 		print "TimerPath: ", default, tmp
-		self.timer_dirname = ConfigSelection(default = default, choices = self.styles+tmp)
-		tmp = config.movielist.videodirs.value
-		default = config.usage.instantrec_path.value
-		if default not in tmp and default not in styles_keys:
-			tmp = tmp[:]
-			tmp.append(default)
-# 		print "InstantrecPath: ", default, tmp
-		self.instantrec_dirname = ConfigSelection(default = default, choices = self.styles+tmp)
-		self.default_dirname.addNotifier(self.checkReadWriteDir, initial_call=False, immediate_feedback=False)
-		self.timer_dirname.addNotifier(self.checkReadWriteDir, initial_call=False, immediate_feedback=False)
-		self.instantrec_dirname.addNotifier(self.checkReadWriteDir, initial_call=False, immediate_feedback=False)
-
-		list = []
-
-		if config.usage.setup_level.index >= 2:
-			self.default_entry = getConfigListEntry(_("Default movie location"), self.default_dirname, _("Set the default location for your recordings. Press 'OK' to add new locations, select left/right to select an existing location."))
-			list.append(self.default_entry)
-			self.timer_entry = getConfigListEntry(_("Timer recording location"), self.timer_dirname, _("Set the default location for your timers. Press 'OK' to add new locations, select left/right to select an existing location."))
-			list.append(self.timer_entry)
-			self.instantrec_entry = getConfigListEntry(_("Instant recording location"), self.instantrec_dirname, _("Set the default location for your instant recordings. Press 'OK' to add new locations, select left/right to select an existing location."))
-			list.append(self.instantrec_entry)
-		else:
-			self.default_entry = getConfigListEntry(_("Movie location"), self.default_dirname, _("Set the default location for your recordings. Press 'OK' to add new locations, select left/right to select an existing location."))
-			list.append(self.default_entry)
-
-		self.refill(list)
-		self["config"].setList(list)
-		if config.usage.sort_settings.value:
-			self["config"].list.sort()
+			self["config"].setCurrentIndex(self.errorItem)
 
 	def changedEntry(self):
-		if self["config"].getCurrent()[0] in (_("Default movie location"), _("Timer record location"), _("Instant record location"), _("Movie location")):
-			self.checkReadWriteDir(self["config"].getCurrent()[1])
+		if self.getCurrentItem() in (config.usage.default_path, config.usage.timer_path, config.usage.instantrec_path):
+			self.pathStatus(self.getCurrentValue())
+		Setup.changedEntry(self)
 
-	def ok(self):
-		currentry = self["config"].getCurrent()
-		self.lastvideodirs = config.movielist.videodirs.value
-		self.lasttimeshiftdirs = config.usage.allowed_timeshift_paths.value
-		if config.usage.setup_level.index >= 2:
-			txt = _("Default movie location")
+	def keySelect(self):
+		item = self.getCurrentItem()
+		if item in (config.usage.default_path, config.usage.timer_path, config.usage.instantrec_path):
+			# print("[Recordings] DEBUG: '%s', '%s', '%s'." % (self.getCurrentEntry(), item.value, preferredPath(item.value)))
+			self.session.openWithCallback(self.pathSelect, MovieLocationBox, self.getCurrentEntry(), preferredPath(item.value))
 		else:
-			txt = _("Movie location")
-		if currentry == self.default_entry:
-			self.entrydirname = self.default_dirname
-			self.session.openWithCallback(
-				self.dirnameSelected,
-				MovieLocationBox,
-				txt,
-				preferredPath(self.default_dirname.value)
-			)
-		elif currentry == self.timer_entry:
-			self.entrydirname = self.timer_dirname
-			self.session.openWithCallback(
-				self.dirnameSelected,
-				MovieLocationBox,
-				_("New timers location"),
-				preferredPath(self.timer_dirname.value)
-			)
-		elif currentry == self.instantrec_entry:
-			self.entrydirname = self.instantrec_dirname
-			self.session.openWithCallback(
-				self.dirnameSelected,
-				MovieLocationBox,
-				_("Instant recordings location"),
-				preferredPath(self.instantrec_dirname.value)
-			)
+			Setup.keySelect(self)
 
-	def dirnameSelected(self, res):
-		if res is not None:
-			self.entrydirname.value = res
-			if config.movielist.videodirs.value != self.lastvideodirs:
-				styles_keys = [x[0] for x in self.styles]
-				tmp = config.movielist.videodirs.value
-				default = self.default_dirname.value
-				if default not in tmp:
-					tmp = tmp[:]
-					tmp.append(default)
-				self.default_dirname.setChoices(tmp, default=default)
-				tmp = config.movielist.videodirs.value
-				default = self.timer_dirname.value
-				if default not in tmp and default not in styles_keys:
-					tmp = tmp[:]
-					tmp.append(default)
-				self.timer_dirname.setChoices(self.styles+tmp, default=default)
-				tmp = config.movielist.videodirs.value
-				default = self.instantrec_dirname.value
-				if default not in tmp and default not in styles_keys:
-					tmp = tmp[:]
-					tmp.append(default)
-				self.instantrec_dirname.setChoices(self.styles+tmp, default=default)
-				self.entrydirname.value = res
-			if self.entrydirname.last_value != res:
-				self.checkReadWriteDir(self.entrydirname)
-
-	def saveAll(self):
-		currentry = self["config"].getCurrent()
-		config.usage.default_path.value = self.default_dirname.value
-		config.usage.timer_path.value = self.timer_dirname.value
-		config.usage.instantrec_path.value = self.instantrec_dirname.value
-		config.usage.default_path.save()
-		config.usage.timer_path.save()
-		config.usage.instantrec_path.save()
-		ConfigListScreen.saveAll(self)
-
-	def createSummary(self):
-		return SetupSummary
-
-	def addItems(self, list, parentNode):
-		for x in parentNode:
-			if not x.tag:
-				continue
-			if x.tag == 'item':
-				item_level = int(x.get("level", 0))
-
-				if not self.levelChanged in config.usage.setup_level.notifiers:
-					config.usage.setup_level.notifiers.append(self.levelChanged)
-					self.onClose.append(self.removeNotifier)
-
-				if item_level > config.usage.setup_level.index:
-					continue
-
-				requires = x.get("requires")
-				if requires and requires.startswith('config.'):
-					item = eval(requires or "")
-					if item.value and not item.value == "0":
-						SystemInfo[requires] = True
-					else:
-						SystemInfo[requires] = False
-
-				if requires and not SystemInfo.get(requires, False):
-					continue
-
-				item_text = _(x.get("text", "??").encode("UTF-8"))
-				item_description = _(x.get("description", " ").encode("UTF-8"))
-				b = eval(x.text or "")
-				if b == "":
-					continue
-				#add to configlist
-				item = b
-				# the first b is the item itself, ignored by the configList.
-				# the second one is converted to string.
-				if not isinstance(item, ConfigNothing):
-					list.append((item_text, item, item_description))
+	def keySave(self):
+		if self.errorItem == -1:
+			Setup.keySave(self)
+		else:
+			self.session.open(MessageBox, "%s\n\n%s" % (self.getFootnote(), _("Please select an acceptable directory.")), type=MessageBox.TYPE_ERROR)


### PR DESCRIPTION
[Recordings.py] Refactor code to sub class Setup
- This update should be functionally the same as the previous version except that rather than copying parts of the "Setup" code this version uses the "Setup" code directly.

- There is one functional difference in that if any of the recording directories is invalid, using the Flash or read only media, the GREEN button will be disabled and the user can not leave the setting entry field until a valid entry is selected.

[setup.xml] Support refactored Recordings.py

[UsageConfig.py] Support Recording.py refactor
- This change changes the three paths used in the Recordings.py UI from ConfigText to ConfigSelection types to better reflect the UI.
