### PR TITLE
Refactor Timeshift.py

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -301,7 +301,8 @@
 		<item level="2" text="e-mail address" description="Enter your e-mail address to send a copy of the log to.">config.logmanager.useremail</item>
 		<item level="2" text="Send yourself a copy" description="Allows you to send a copy of the log to yourself.">config.logmanager.usersendcopy</item>
 	</setup>
-	<setup key="timeshift" title="Timeshift">
+	<setup key="Timeshift" title="Timeshift">
+		<item level="0" text="Timeshift location" description="Set the default location for your timeshift files. Press OK to add new locations, LEFT/RIGHT to select any existing locations.">config.usage.timeshift_path</item>
 		<item level="1" text="Automatically start timeshift after" description="When enabled, timeshift starts automatically in background after the specified time.">config.timeshift.startdelay</item>
 		<item level="1" text="Show warning when timeshift is stopped" description="When enabled, a warning will be displayed and the user will get an option to stop or to continue the timeshift.">config.usage.check_timeshift</item>
 		<item level="2" text="Timeshift-save action on zap" description="Select if timeshift should continue when set to record.">config.timeshift.favoriteSaveAction</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -160,20 +160,17 @@ def InitUsageConfig():
 
 	if not os.path.exists(resolveFilename(SCOPE_TIMESHIFT)):
 		try:
-			os.mkdir(resolveFilename(SCOPE_TIMESHIFT),0755)
+			os.mkdir(resolveFilename(SCOPE_TIMESHIFT), 0755)
 		except:
 			pass
-	config.usage.timeshift_path = ConfigText(default = resolveFilename(SCOPE_TIMESHIFT))
-	if not config.usage.default_path.value.endswith('/'):
-		tmpvalue = config.usage.timeshift_path.value
-		config.usage.timeshift_path.setValue(tmpvalue + '/')
-		config.usage.timeshift_path.save()
-	def timeshiftpathChanged(configElement):
-		if not config.usage.timeshift_path.value.endswith('/'):
-			tmpvalue = config.usage.timeshift_path.value
-			config.usage.timeshift_path.setValue(tmpvalue + '/')
-			config.usage.timeshift_path.save()
-	config.usage.timeshift_path.addNotifier(timeshiftpathChanged, immediate_feedback = False)
+	defaultValue = resolveFilename(SCOPE_TIMESHIFT)
+	config.usage.timeshift_path = ConfigSelection(default=defaultValue, choices=[(defaultValue, defaultValue)])
+	config.usage.timeshift_path.load()
+	if config.usage.timeshift_path.saved_value:
+		savedValue = os.path.join(config.usage.timeshift_path.saved_value, "")
+		if savedValue and savedValue != defaultValue:
+			config.usage.timeshift_path.setChoices([(defaultValue, defaultValue), (savedValue, savedValue)], default=defaultValue)
+	config.usage.timeshift_path.save()
 	config.usage.allowed_timeshift_paths = ConfigLocations(default = [resolveFilename(SCOPE_TIMESHIFT)])
 
 	config.usage.trashsort_deltime = ConfigSelection(default = "no", choices = [

--- a/lib/python/Screens/Timeshift.py
+++ b/lib/python/Screens/Timeshift.py
@@ -1,297 +1,113 @@
-from Screens.Screen import Screen
-from Screens.Setup import setupdom
-from Screens.LocationBox import TimeshiftLocationBox
+from os import link, remove, stat
+from os.path import isdir, join as pathJoin, splitext
+from tempfile import NamedTemporaryFile
+
+from Components.config import config
+from Screens.LocationBox import defaultInhibitDirs, TimeshiftLocationBox
 from Screens.MessageBox import MessageBox
-from Components.Label import Label
-from Components.config import config, configfile, ConfigYesNo, ConfigNothing, ConfigSelection, getConfigListEntry
-from Components.ConfigList import ConfigListScreen
-from Components.ActionMap import ActionMap
-from Components.Pixmap import Pixmap
+from Screens.Setup import Setup
 from Tools.Directories import fileExists
-from Components.Sources.Boolean import Boolean
-from Components.Sources.StaticText import StaticText
-from Components.SystemInfo import SystemInfo
 
 
-class SetupSummary(Screen):
-	def __init__(self, session, parent):
-		Screen.__init__(self, session, parent = parent)
-		self["SetupTitle"] = StaticText(parent.getTitle())
-		self["SetupEntry"] = StaticText("")
-		self["SetupValue"] = StaticText("")
-		self.onShow.append(self.addWatcher)
-		self.onHide.append(self.removeWatcher)
+class TimeshiftSettings(Setup):
+	def __init__(self, session):
+		self.inhibitDevs = []
+		for dir in defaultInhibitDirs + ["/", "/media"]:
+			if isdir(dir):
+				device = stat(dir).st_dev
+				if device not in self.inhibitDevs:
+					self.inhibitDevs.append(device)
+		self.buildChoices("TimeshiftPath", config.usage.timeshift_path, None)
+		Setup.__init__(self, session=session, setup="Timeshift")
+		self.greenText = self["key_green"].text
+		self.errorItem = -1
+		if self.getCurrentItem() is config.usage.timeshift_path:
+			self.pathStatus(self.getCurrentValue())
 
-	def addWatcher(self):
-		self.parent.onChangedEntry.append(self.selectionChanged)
-		self.parent["config"].onSelectionChanged.append(self.selectionChanged)
-		self.selectionChanged()
+	def buildChoices(self, item, configEntry, path):
+		configList = config.usage.allowed_timeshift_paths.value[:]
+		if configEntry.saved_value and configEntry.saved_value not in configList:
+			configList.append(configEntry.saved_value)
+			configEntry.value = configEntry.saved_value
+		if path is None:
+			path = configEntry.value
+		if path and path not in configList:
+			configList.append(path)
+		pathList = [(x, x) for x in configList]
+		configEntry.value = path
+		configEntry.setChoices(pathList, default=configEntry.default)
+		print("[Timeshift] %s: Current='%s', Default='%s', Choices='%s'" % (item, configEntry.value, configEntry.default, configList))
 
-	def removeWatcher(self):
-		self.parent.onChangedEntry.remove(self.selectionChanged)
-		self.parent["config"].onSelectionChanged.remove(self.selectionChanged)
+	def pathSelect(self, path):
+		if path is not None:
+			path = pathJoin(path, "")
+			self.buildChoices("TimeshiftPath", config.usage.timeshift_path, path)
+		self["config"].invalidateCurrent()
+		self.changedEntry()
+
+	def pathStatus(self, path):
+		self.errorItem = -1
+		self.setFootnote("")
+		self["key_green"].text = self.greenText
+		if stat(path).st_dev in self.inhibitDevs:
+			self.errorItem = self["config"].getCurrentIndex()
+			self.setFootnote(_("Flash directory '%s' not allowed!") % path)
+			self["key_green"].text = ""
+		elif not fileExists(path, "w"):
+			self.errorItem = self["config"].getCurrentIndex()
+			self.setFootnote(_("Directory '%s' not writeable!") % path)
+			self["key_green"].text = ""
+		elif not self.hasHardLinks(path):
+			self.errorItem = self["config"].getCurrentIndex()
+			self.setFootnote(_("Directory '%s' can't be linked to recordings!") % path)
+			self["key_green"].text = ""
+
+	def hasHardLinks(self, path):
+		try:
+			tmpfile = NamedTemporaryFile(suffix='.file', prefix='tmp', dir=path, delete=False)
+		except (IOError, OSError) as err:
+			print("[Timeshift] DEBUG: Create temp file - I/O Error %d: %s!" % (err.errno, err.strerror))
+			return False
+		srcname = tmpfile.name
+		tmpfile.close()
+		dstname = "%s.link" % splitext(srcname)[0]
+		try:
+			link(srcname, dstname)
+			result = True
+		except (IOError, OSError) as err:
+			print("[Timeshift] DEBUG: Create link - I/O Error %d: %s!" % (err.errno, err.strerror))
+			result = False
+		try:
+			remove(srcname)
+		except (IOError, OSError) as err:
+			print("[Timeshift] DEBUG: Remove source - I/O Error %d: %s!" % (err.errno, err.strerror))
+			pass
+		try:
+			remove(dstname)
+		except (IOError, OSError) as err:
+			print("[Timeshift] DEBUG: Remove target - I/O Error %d: %s!" % (err.errno, err.strerror))
+			pass
+		return result
 
 	def selectionChanged(self):
-		self["SetupEntry"].text = self.parent.getCurrentEntry()
-		self["SetupValue"].text = self.parent.getCurrentValue()
-		if hasattr(self.parent,"getCurrentDescription"):
-			self.parent["description"].text = self.parent.getCurrentDescription()
-		if self.parent.has_key('footnote'):
-			if self.parent.getCurrentEntry().endswith('*'):
-				self.parent['footnote'].text = (_("* = Restart Required"))
-			else:
-				self.parent['footnote'].text = ("")
+		if self.errorItem == -1:
+			Setup.selectionChanged(self)
+		else:
+			self["config"].setCurrentIndex(self.errorItem)
 
-class TimeshiftSettings(Screen,ConfigListScreen):
-	def removeNotifier(self):
-		config.usage.setup_level.notifiers.remove(self.levelChanged)
-
-	def levelChanged(self, configElement):
-		list = []
-		self.refill(list)
-		self["config"].setList(list)
-
-	def refill(self, list):
-		xmldata = setupdom().getroot()
-		for x in xmldata.findall("setup"):
-			if x.get("key") != self.setup:
-				continue
-			self.addItems(list, x)
-			self.setTitle(_(x.get("title", "Setup").encode("UTF-8")))
-			self.seperation = int(x.get('separation', '0'))
-
-	def __init__(self, session):
-		Screen.__init__(self, session)
-		self.skinName = "Setup"
-		self['footnote'] = Label()
-		self["HelpWindow"] = Pixmap()
-		self["HelpWindow"].hide()
-		self["VKeyIcon"] = Boolean(False)
-
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
-		self["description"] = Label("")
-
-		self.onChangedEntry = [ ]
-		self.setup = "timeshift"
-		list = []
-		ConfigListScreen.__init__(self, list, session = session, on_change = self.changedEntry)
-		self.createSetup()
-
-		self["setupActions"] = ActionMap(["SetupActions", "ColorActions", "MenuActions"],
-		{
-			"green": self.keySave,
-			"red": self.keyCancel,
-			"cancel": self.keyCancel,
-			"ok": self.ok,
-			"menu": self.closeRecursive,
-		}, -2)
-
-	# for summary:
 	def changedEntry(self):
-		self.item = self["config"].getCurrent()
-		if self["config"].getCurrent()[0] == _("Timeshift location"):
-			self.checkReadWriteDir(self["config"].getCurrent()[1])
-		for x in self.onChangedEntry:
-			x()
-		try:
-			if isinstance(self["config"].getCurrent()[1], ConfigYesNo) or isinstance(self["config"].getCurrent()[1], ConfigSelection):
-				self.createSetup()
-		except:
-			pass
+		if self.getCurrentItem() is config.usage.timeshift_path:
+			self.pathStatus(self.getCurrentValue())
+		Setup.changedEntry(self)
 
-	def checkReadWriteDir(self, configele):
-		import os.path
-		import Components.Harddisk
-		supported_filesystems = frozenset(('ext4', 'ext3', 'ext2', 'nfs'))
-		candidates = []
-		mounts = Components.Harddisk.getProcMounts()
-		for partition in Components.Harddisk.harddiskmanager.getMountedPartitions(False, mounts):
-			if partition.filesystem(mounts) in supported_filesystems:
-				candidates.append((partition.description, partition.mountpoint))
-		if candidates:
-			locations = []
-			for validdevice in candidates:
-				locations.append(validdevice[1])
-			if Components.Harddisk.findMountPoint(os.path.realpath(configele.value))+'/' in locations or Components.Harddisk.findMountPoint(os.path.realpath(configele.value)) in locations:
-				if fileExists(configele.value, "w"):
-					configele.last_value = configele.value
-					return True
-				else:
-					dir = configele.value
-					configele.value = configele.last_value
-					self.session.open(
-						MessageBox,
-						_("The directory %s is not writable.\nMake sure you select a writable directory instead.")%dir,
-						type = MessageBox.TYPE_ERROR
-						)
-					return False
-			else:
-				dir = configele.value
-				configele.value = configele.last_value
-				self.session.open(
-					MessageBox,
-					_("The directory %s is not a EXT2, EXT3, EXT4 or NFS partition.\nMake sure you select a valid partition type.")%dir,
-					type = MessageBox.TYPE_ERROR
-					)
-				return False
+	def keySelect(self):
+		if self.getCurrentItem() is config.usage.timeshift_path:
+			self.session.openWithCallback(self.pathSelect, TimeshiftLocationBox)
 		else:
-			dir = configele.value
-			configele.value = configele.last_value
-			self.session.open(
-				MessageBox,
-				_("The directory %s is not a EXT2, EXT3, EXT4 or NFS partition.\nMake sure you select a valid partition type.")%dir,
-				type = MessageBox.TYPE_ERROR
-				)
-			return False
+			Setup.keySelect(self)
 
-	def createSetup(self):
-		default = config.usage.timeshift_path.value
-		tmp = config.usage.allowed_timeshift_paths.value
-		if default not in tmp:
-			tmp = tmp[:]
-			tmp.append(default)
-# 		print "TimeshiftPath: ", default, tmp
-		self.timeshift_dirname = ConfigSelection(default = default, choices = tmp)
-		self.timeshift_dirname.addNotifier(self.checkReadWriteDir, initial_call=False, immediate_feedback=False)
-		list = []
-		self.timeshift_entry = getConfigListEntry(_("Timeshift location"), self.timeshift_dirname, _("Set the default location for your timeshift-files. Press 'OK' to add new locations, select left/right to select an existing location."))
-		list.append(self.timeshift_entry)
-
-		self.refill(list)
-		self["config"].setList(list)
-		if config.usage.sort_settings.value:
-			self["config"].list.sort()
-
-	def ok(self):
-		currentry = self["config"].getCurrent()
-		self.lastvideodirs = config.movielist.videodirs.value
-		self.lasttimeshiftdirs = config.usage.allowed_timeshift_paths.value
-		if currentry == self.timeshift_entry:
-			self.entrydirname = self.timeshift_dirname
-			config.usage.timeshift_path.value = self.timeshift_dirname.value
-			self.session.openWithCallback(
-				self.dirnameSelected,
-				TimeshiftLocationBox
-			)
-
-	def dirnameSelected(self, res):
-		if res is not None:
-			import os.path
-			import Components.Harddisk
-			supported_filesystems = frozenset(('ext4', 'ext3', 'ext2', 'nfs'))
-			candidates = []
-			mounts = Components.Harddisk.getProcMounts()
-			for partition in Components.Harddisk.harddiskmanager.getMountedPartitions(False, mounts):
-				if partition.filesystem(mounts) in supported_filesystems:
-					candidates.append((partition.description, partition.mountpoint))
-			if candidates:
-				locations = []
-				for validdevice in candidates:
-					locations.append(validdevice[1])
-				if Components.Harddisk.findMountPoint(os.path.realpath(res))+'/' in locations or Components.Harddisk.findMountPoint(os.path.realpath(res)) in locations:
-					self.entrydirname.value = res
-					if config.usage.allowed_timeshift_paths.value != self.lasttimeshiftdirs:
-						tmp = config.usage.allowed_timeshift_paths.value
-						default = self.timeshift_dirname.value
-						if default not in tmp:
-							tmp = tmp[:]
-							tmp.append(default)
-						self.timeshift_dirname.setChoices(tmp, default=default)
-						self.entrydirname.value = res
-				else:
-					self.session.open(
-						MessageBox,
-						_("The directory %s is not a EXT2, EXT3, EXT4 or NFS partition.\nMake sure you select a valid partition type.")%res,
-						type = MessageBox.TYPE_ERROR
-						)
-			else:
-				self.session.open(
-					MessageBox,
-					_("The directory %s is not a EXT2, EXT3, EXT4 or NFS partition.\nMake sure you select a valid partition type.")%res,
-					type = MessageBox.TYPE_ERROR
-					)
-
-	# keySave and keyCancel are just provided in case you need them.
-	# you have to call them by yourself.
 	def keySave(self):
-		import os.path
-		import Components.Harddisk
-		supported_filesystems = frozenset(('ext4', 'ext3', 'ext2', 'nfs'))
-		candidates = []
-		mounts = Components.Harddisk.getProcMounts()
-		for partition in Components.Harddisk.harddiskmanager.getMountedPartitions(False, mounts):
-			if partition.filesystem(mounts) in supported_filesystems:
-				candidates.append((partition.description, partition.mountpoint))
-		if candidates:
-			locations = []
-			for validdevice in candidates:
-				locations.append(validdevice[1])
-			if Components.Harddisk.findMountPoint(os.path.realpath(config.usage.timeshift_path.value))+'/' in locations or Components.Harddisk.findMountPoint(os.path.realpath(config.usage.timeshift_path.value)) in locations:
-				config.usage.timeshift_path.value = self.timeshift_dirname.value
-				config.usage.timeshift_path.save()
-				self.saveAll()
-				self.close()
-			else:
-				if int(config.timeshift.startdelay.value) > 0:
-					self.session.open(
-						MessageBox,
-						_("The directory %s is not a EXT2, EXT3, EXT4 or NFS partition.\nMake sure you select a valid partition type.")%config.usage.timeshift_path.value,
-						type = MessageBox.TYPE_ERROR
-						)
-				else:
-					config.timeshift.startdelay.setValue(0)
-					self.saveAll()
-					self.close()
+		if self.errorItem == -1:
+			Setup.keySave(self)
 		else:
-			if int(config.timeshift.startdelay.value) > 0:
-				self.session.open(
-					MessageBox,
-					_("The directory %s is not a EXT2, EXT3, EXT4 or NFS partition.\nMake sure you select a valid partition type.")%config.usage.timeshift_path.value,
-					type = MessageBox.TYPE_ERROR
-					)
-			else:
-				config.timeshift.startdelay.setValue(0)
-				self.saveAll()
-				self.close()
-
-	def createSummary(self):
-		return SetupSummary
-
-	def addItems(self, list, parentNode):
-		for x in parentNode:
-			if not x.tag:
-				continue
-			if x.tag == 'item':
-				item_level = int(x.get("level", 0))
-
-				if not self.levelChanged in config.usage.setup_level.notifiers:
-					config.usage.setup_level.notifiers.append(self.levelChanged)
-					self.onClose.append(self.removeNotifier)
-
-				if item_level > config.usage.setup_level.index:
-					continue
-
-				requires = x.get("requires")
-				if requires and requires.startswith('config.'):
-					item = eval(requires or "")
-					if item.value and not item.value == "0":
-						SystemInfo[requires] = True
-					else:
-						SystemInfo[requires] = False
-
-				if requires and not SystemInfo.get(requires, False):
-					continue
-
-				item_text = _(x.get("text", "??").encode("UTF-8"))
-				item_description = _(x.get("description", " ").encode("UTF-8"))
-				b = eval(x.text or "")
-				if b == "":
-					continue
-				#add to configlist
-				item = b
-				# the first b is the item itself, ignored by the configList.
-				# the second one is converted to string.
-				if not isinstance(item, ConfigNothing):
-					list.append((item_text, item, item_description))
-
+			self.session.open(MessageBox, "%s\n\n%s" % (self.getFootnote() % _("Please select an acceptable directory.")), type=MessageBox.TYPE_ERROR)


### PR DESCRIPTION
[Timeshift.py] Refactor code to sub class Setup
- This update should be functionally the same as the previous version except that rather than copying parts of the "Setup" code this version uses the "Setup" code directly.

- There is one functional difference in that if the timeshift directory is invalid, using the Flash, read only media or doesn't support hard links, the GREEN button will be disabled and the user can not leave the setting entry field until a valid entry is selected.

[setup.xml] Support refactored Timeshift.py

[UsageConfig.py] Support Timeshift.py refactor
- This change shifts the path used in the Timeshift.py UI from ConfigText to ConfigSelection to better reflect the UI.
