### PR TITLE
[config.py] Refactor ConfigSet

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1574,87 +1574,87 @@ class ConfigSatlist(ConfigSelection):
 #
 class ConfigSet(ConfigElement):
 	def __init__(self, choices, default=None):
-		if not default:
-			default = []
 		ConfigElement.__init__(self)
 		if isinstance(choices, list):
 			choices.sort()
 			self.choices = choicesList(choices, choicesList.LIST_TYPE_LIST)
 		else:
-			assert False, "ConfigSet choices must be a list!"
+			assert False, "[Config] Error: 'ConfigSet' choices must be a list!"
 		if default is None:
 			default = []
-		self.pos = -1
 		default.sort()
 		self.last_value = self.default = default
 		self.value = default[:]
-
-	def toggleChoice(self, choice):
-		value = self.value
-		if choice in value:
-			value.remove(choice)
-		else:
-			value.append(choice)
-			value.sort()
-		self.changed()
+		self.pos = 0
 
 	def handleKey(self, key):
-		if key in K[KEYA_TOGGLE, KEYA_SELECT, KEYA_DELETE, KEYA_BACKSPACE] + KEYA_NUMBERS:
-			if self.pos != -1:
-				self.toggleChoice(self.choices[self.pos])
+		if key in [KEYA_TOGGLE, KEYA_SELECT, KEYA_DELETE, KEYA_BACKSPACE] + KEYA_NUMBERS:
+			value = self.value
+			choice = self.choices[self.pos]
+			if choice in value:
+				value.remove(choice)
+			else:
+				value.append(choice)
+				value.sort()
+			self.changed()
 		elif key == KEYA_LEFT:
-			if self.pos < 0:
-				self.pos = len(self.choices) - 1
-			else:
+			if self.pos > 0:
 				self.pos -= 1
+			else:
+				self.pos = len(self.choices) - 1
 		elif key == KEYA_RIGHT:
-			if self.pos >= len(self.choices) - 1:
-				self.pos = -1
-			else:
+			if self.pos < len(self.choices) - 1:
 				self.pos += 1
-		elif key in (KEYA_FIRST, KEYA_LAST):
-			self.pos = -1
-
-	def genString(self, lst):
-		res = ""
-		for x in lst:
-			res += self.description[x] + " "
-		return res
-
-	def getText(self):
-		return self.genString(self.value)
-
-	def getMulti(self, selected):
-		if not selected or self.pos == -1:
-			return "text", self.genString(self.value)
-		else:
-			tmp = self.value[:]
-			ch = self.choices[self.pos]
-			mem = ch in self.value
-			if not mem:
-				tmp.append(ch)
-				tmp.sort()
-			ind = tmp.index(ch)
-			val1 = self.genString(tmp[:ind])
-			val2 = " " + self.genString(tmp[ind + 1:])
-			if mem:
-				chstr = " " + self.description[ch] + " "
 			else:
-				chstr = "(" + self.description[ch] + ")"
-			len_val1 = len(val1)
-			return "mtext", val1 + chstr + val2, range(len_val1, len_val1 + len(chstr))
+				self.pos = 0
+		elif key == KEYA_FIRST:
+			self.pos = 0
+		elif key == KEYA_LAST:
+			self.pos = len(self.choices) - 1
 
-	def onDeselect(self, session):
-		self.pos = -1
-		if not self.last_value == self.value:
-			self.changedFinal()
-			self.last_value = self.value[:]
-
-	def tostring(self, value):
-		return str(value)
+	def load(self):
+		ConfigElement.load(self)
+		if not self.value:
+			self.value = []
+		if not isinstance(self.value, list):
+			self.value = list(self.value)
+		self.value.sort()
 
 	def fromstring(self, val):
 		return eval(val)
+
+	def tostring(self, val):
+		return str(val)
+
+	def toDisplayString(self, val):
+		return ", ".join([self.description[x] for x in val])
+
+	def getText(self):
+		return " ".join([self.description[x] for x in self.value])
+
+	def getMulti(self, selected):
+		if selected:
+			text = []
+			pos = 0
+			start = 0
+			end = 0
+			for item in self.choices:
+				itemStr = str(item)
+				text.append(" %s " % itemStr if item in self.value else "(%s)" % itemStr)
+				length = 2 + len(itemStr)
+				if item == self.choices[self.pos]:
+					start = pos
+					end = start + length
+				pos += length
+			return "mtext", "".join(text), range(start, end)
+		else:
+			return "text", " ".join([self.description[x] for x in self.value])
+
+	def onDeselect(self, session):
+		# self.pos = 0  # Enable this to reset the position marker to the first element.
+		if self.last_value != self.value:
+			self.changedFinal()
+			self.last_value = self.value[:]
 
 	description = property(lambda self: descriptionList(self.choices.choices, choicesList.LIST_TYPE_LIST))
 


### PR DESCRIPTION
- Make ConfigSet responsive to KEYA_TOGGLE and KEYA_SELECT.  This will address the issue of being unable to change selections.
- Rework the UI to make it more clear what is going on.  Now all members in the set will be shown when the element is selected.  Inactive members of the set will be shown in brackets ().  As the user navigates left and right along the set members pressing OK will toggle if that member is selected or deselected to be included in the set.
- Update ConfigText to also use the renamed KEYA_TOGGLE.
- Protect the code from illegal values saved in the "settings" file.  (ConfigSet requires a list as its value.)
