### PR TITLE
[config.py] Capitalise Boolean GUI strings

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -506,11 +506,12 @@ class ConfigSelection(ConfigElement):
 # Several customized versions exist for different descriptions.
 #
 class ConfigBoolean(ConfigElement):
-	def __init__(self, default=False, descriptions={False: _("false"), True: _("true")}, graphic=True):
+	def __init__(self, default=False, descriptions={False: _("False"), True: _("True")}, graphic=True):
 		ConfigElement.__init__(self)
 		self.value = self.last_value = self.default = default
 		self.descriptions = descriptions
 		self.graphic = graphic
+		self.trueValues = ("1", "enable", "on", "true", "yes")
 
 	def handleKey(self, key):
 		if key in (KEYA_TOGGLE, KEYA_SELECT, KEYA_LEFT, KEYA_RIGHT):
@@ -521,15 +522,15 @@ class ConfigBoolean(ConfigElement):
 			self.value = True
 
 	def fromstring(self, val):
-		return str(val).lower() in ("1", "enable", "on", "true", "yes")
+		return str(val).lower() in self.trueValues
 
 	def tostring(self, value):
-		return "True" if value or str(value).lower() in ("1", "enable", "on", "true", "yes") else "False"
+		return "True" if value or str(value).lower() in self.trueValues else "False"
 		# Use the following if settings should be saved using the same values as displayed to the user.
 		# self.descriptions[True] if value or str(value).lower() in ("1", "enable", "on", "true", "yes") else self.descriptions[True]
 
 	def toDisplayString(self, value):
-		return self.descriptions[True] if value or str(value).lower() in ["true", self.descriptions[True].lower()] else self.descriptions[False]
+		return self.descriptions[True] if value or str(value).lower() in self.trueValues else self.descriptions[False]
 
 	def getText(self):
 		return self.descriptions[self.value]
@@ -552,22 +553,22 @@ class ConfigBoolean(ConfigElement):
 		return "<input type=\"checkbox\" name=\"%s\" value=\"1\"%s />" % (id, " checked=\"checked\"" if self.value else "")
 
 	def unsafeAssign(self, value):  # DEBUG: Is this still used?
-		self.value = value.lower() in ("1", "enable", "on", "true", "yes")
+		self.value = value.lower() in self.trueValues
 
 
 class ConfigEnableDisable(ConfigBoolean):
 	def __init__(self, default=False, graphic=True):
-		ConfigBoolean.__init__(self, default=default, descriptions={False: _("disable"), True: _("enable")}, graphic=graphic)
+		ConfigBoolean.__init__(self, default=default, descriptions={False: _("Disable"), True: _("Enable")}, graphic=graphic)
 
 
 class ConfigOnOff(ConfigBoolean):
 	def __init__(self, default=False, graphic=True):
-		ConfigBoolean.__init__(self, default=default, descriptions={False: _("off"), True: _("on")}, graphic=graphic)
+		ConfigBoolean.__init__(self, default=default, descriptions={False: _("Off"), True: _("On")}, graphic=graphic)
 
 
 class ConfigYesNo(ConfigBoolean):
 	def __init__(self, default=False, graphic=True):
-		ConfigBoolean.__init__(self, default=default, descriptions={False: _("no"), True: _("yes")}, graphic=graphic)
+		ConfigBoolean.__init__(self, default=default, descriptions={False: _("No"), True: _("Yes")}, graphic=graphic)
 
 
 class ConfigDateTime(ConfigElement):


### PR DESCRIPTION
- Change the display of all Boolean strings to first letter uppercase.
- Centralise the list of strings that represent a True Boolean to a common variable to make future maintenance easier.
