### PR TITLE
ConfigList and Setup improvements

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -380,24 +380,24 @@ class ConfigListScreen:
 		self.entryChanged()
 
 	def keySave(self):
-		self.saveAll()
-		if self.restart:
+		if self.saveAll():
 			self.session.openWithCallback(self.restartConfirm, MessageBox, self.restartMsg, default=True, type=MessageBox.TYPE_YESNO)
 		else:
 			self.close()
-
-	def saveAll(self):
-		self.restart = False
-		for x in self["config"].list:
-			if x[0].endswith("*") and x[1].isChanged():
-				self.restart = True
-			x[1].save()
-		configfile.save()
 
 	def restartConfirm(self, result):
 		if result:
 			self.session.open(TryQuitMainloop, retvalue=QUIT_RESTART)
 			self.close()
+
+	def saveAll(self):
+		restart = False
+		for x in self["config"].list:
+			if x[0].endswith("*") and x[1].isChanged():
+				restart = True
+			x[1].save()
+		configfile.save()
+		return restart
 
 	def keyCancel(self):
 		self.closeConfigList(())

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -21,8 +21,6 @@ setupTitles = {}
 
 
 class Setup(ConfigListScreen, Screen, HelpableScreen):
-	ALLOW_SUSPEND = True
-
 	def __init__(self, session, setup, plugin=None, PluginLanguageDomain=None):
 		Screen.__init__(self, session)
 		HelpableScreen.__init__(self)


### PR DESCRIPTION
[ConfigList.py] Optimise the previous commit
- This version does not create and use another shared variable.

[Setup.py] Disallow POWER while in Setup
- This change disables the POWER button while users are in the Setup menus.  This has been done to avoid issues of any pending changes not being saved.
