### PR TITLE
Fix timeshift setting initialisation

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -165,6 +165,7 @@ def InitUsageConfig():
 		savedValue = os.path.join(config.usage.timeshift_path.saved_value, "")
 		if savedValue and savedValue != defaultValue:
 			config.usage.timeshift_path.setChoices([(defaultValue, defaultValue), (savedValue, savedValue)], default=defaultValue)
+			config.usage.timeshift_path.value = savedValue
 	config.usage.timeshift_path.save()
 	config.usage.allowed_timeshift_paths = ConfigLocations(default = [resolveFilename(SCOPE_TIMESHIFT)])
 

--- a/lib/python/Screens/Timeshift.py
+++ b/lib/python/Screens/Timeshift.py
@@ -46,21 +46,28 @@ class TimeshiftSettings(Setup):
 		self.changedEntry()
 
 	def pathStatus(self, path):
-		self.errorItem = -1
-		self.setFootnote("")
-		self["key_green"].text = self.greenText
-		if stat(path).st_dev in self.inhibitDevs:
+		if not isdir(path):
 			self.errorItem = self["config"].getCurrentIndex()
-			self.setFootnote(_("Flash directory '%s' not allowed!") % path)
-			self["key_green"].text = ""
+			footnote = _("Directory '%s' does not exist!") % path
+			green = ""
+		elif stat(path).st_dev in self.inhibitDevs:
+			self.errorItem = self["config"].getCurrentIndex()
+			footnote = _("Flash directory '%s' not allowed!") % path
+			green = ""
 		elif not fileExists(path, "w"):
 			self.errorItem = self["config"].getCurrentIndex()
-			self.setFootnote(_("Directory '%s' not writeable!") % path)
-			self["key_green"].text = ""
+			footnote = _("Directory '%s' not writeable!") % path
+			green = ""
 		elif not self.hasHardLinks(path):
 			self.errorItem = self["config"].getCurrentIndex()
-			self.setFootnote(_("Directory '%s' can't be linked to recordings!") % path)
-			self["key_green"].text = ""
+			footnote = _("Directory '%s' can't be linked to recordings!") % path
+			green = ""
+		else:
+			self.errorItem = -1
+			footnote = ""
+			green = self.greenText
+		self.setFootnote(footnote)
+		self["key_green"].text = green
 
 	def hasHardLinks(self, path):
 		try:


### PR DESCRIPTION
[Timeshift.py] Improve initialisation reliability
- This change avoids a crash if the saved timeshift directory does not exist.

[UsageConfig.py] Correct Timeshift initial load
- Set the current timeshift value to the saved value after resetting the choice options.
