### PR TITLE
Fix recording setting initialisation

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -150,9 +150,25 @@ def InitUsageConfig():
 		savedValue = os.path.join(config.usage.default_path.saved_value, "")
 		if savedValue and savedValue != defaultValue:
 			config.usage.default_path.setChoices([(defaultValue, defaultValue), (savedValue, savedValue)], default=defaultValue)
+			config.usage.default_path.value = savedValue
 	config.usage.default_path.save()
-	config.usage.timer_path = ConfigSelection(default="<default>", choices=[("<default>", "<default>")])
-	config.usage.instantrec_path = ConfigSelection(default="<default>", choices=[("<default>", "<default>")])
+	choiceList = [("<default>", "<default>"), ("<current>", "<current>"), ("<timer>", "<timer>")]
+	config.usage.timer_path = ConfigSelection(default="<default>", choices=choiceList)
+	config.usage.timer_path.load()
+	if config.usage.timer_path.saved_value:
+		savedValue = config.usage.timer_path.saved_value if config.usage.timer_path.saved_value.startswith("<") else os.path.join(config.usage.timer_path.saved_value, "")
+		if savedValue and savedValue not in choiceList:
+			config.usage.timer_path.setChoices(choiceList + [(savedValue, savedValue)], default="<default>")
+			config.usage.timer_path.value = savedValue
+	config.usage.timer_path.save()
+	config.usage.instantrec_path = ConfigSelection(default="<default>", choices=choiceList)
+	config.usage.instantrec_path.load()
+	if config.usage.instantrec_path.saved_value:
+		savedValue = config.usage.instantrec_path.saved_value if config.usage.instantrec_path.saved_value.startswith("<") else os.path.join(config.usage.instantrec_path.saved_value, "")
+		if savedValue and savedValue not in choiceList:
+			config.usage.instantrec_path.setChoices(choiceList + [(savedValue, savedValue)], default="<default>")
+			config.usage.instantrec_path.value = savedValue
+	config.usage.instantrec_path.save()
 	if not os.path.exists(resolveFilename(SCOPE_TIMESHIFT)):
 		try:
 			os.mkdir(resolveFilename(SCOPE_TIMESHIFT), 0755)

--- a/lib/python/Screens/Recordings.py
+++ b/lib/python/Screens/Recordings.py
@@ -63,19 +63,28 @@ class RecordingSettings(Setup):
 		self.changedEntry()
 
 	def pathStatus(self, path):
-		self.errorItem = -1
-		self.setFootnote("")
-		self["key_green"].text = self.greenText
-		if not path.startswith("<"):
-			filedevice = stat(path).st_dev
-			if filedevice in self.inhibitDevs:
-				self.errorItem = self["config"].getCurrentIndex()
-				self.setFootnote(_("Flash directory '%s' not allowed!") % path)
-				self["key_green"].text = ""
-			elif not fileExists(path, "w"):
-				self.errorItem = self["config"].getCurrentIndex()
-				self.setFootnote(_("Directory '%s' not writable!") % path)
-				self["key_green"].text = ""
+		if path.startswith("<"):
+			self.errorItem = -1
+			footnote = ""
+			green = self.greenText
+		elif not isdir(path):
+			self.errorItem = self["config"].getCurrentIndex()
+			footnote = _("Directory '%s' does not exist!") % path
+			green = ""
+		elif stat(path).st_dev in self.inhibitDevs:
+			self.errorItem = self["config"].getCurrentIndex()
+			footnote = _("Flash directory '%s' not allowed!") % path
+			green = ""
+		elif not fileExists(path, "w"):
+			self.errorItem = self["config"].getCurrentIndex()
+			footnote = _("Directory '%s' not writable!") % path
+			green = ""
+		else:
+			self.errorItem = -1
+			footnote = ""
+			green = self.greenText
+		self.setFootnote(footnote)
+		self["key_green"].text = green
 
 	def selectionChanged(self):
 		if self.errorItem == -1:


### PR DESCRIPTION
[Recordings.py] Improve initialisation reliability
- This change avoids a crash if the saved recording directories do not exist.

[UsageConfig.py] Correct Recordings initial load
- Set the current Recordings "default_path", "timer_path" and "instantrec_path" values to the saved values after resetting the choice options.
