### PR TITLE
[ConfigList.py] Fix Boolean update issue

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -284,7 +284,9 @@ class ConfigListScreen:
 					currConf.help_window.hide()
 
 	def keySelect(self):
-		if isinstance(self.getCurrentItem(), ConfigSelection):
+		if isinstance(self.getCurrentItem(), ConfigBoolean):
+			self.keyToggle()
+		elif isinstance(self.getCurrentItem(), ConfigSelection):
 			self.keyMenu()
 		elif isinstance(self.getCurrentItem(), ConfigText):
 			self.keyText()


### PR DESCRIPTION
This change corrects an issue where pressing OK on a Boolean value to toggle the value was not triggering the appropriate "config" list reevaluation.  The LEFT and RIGHT changes were correctly processed.
