### PR TITLE
[config] Fix indexing on empty choices lists in ConfigSelection

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -281,6 +281,8 @@ class choicesList(object):  # XXX: we might want a better name for this
 		return len(self.choices) or 1
 
 	def __getitem__(self, index):
+		if index == 0 and not self.choices:
+			return ""
 		if self.type == choicesList.LIST_TYPE_LIST:
 			ret = self.choices[index]
 			if isinstance(ret, tuple):
@@ -296,6 +298,8 @@ class choicesList(object):  # XXX: we might want a better name for this
 			return 0
 
 	def __setitem__(self, index, value):
+		if index == 0 and not self.choices:
+			return
 		if self.type == choicesList.LIST_TYPE_LIST:
 			orig = self.choices[index]
 			if isinstance(orig, tuple):
@@ -344,6 +348,8 @@ class descriptionList(choicesList):  # XXX: we might want a better name for this
 			return str(self.choices.get(index, ""))
 
 	def __setitem__(self, index, value):
+		if not self.choices:
+			return
 		if self.type == choicesList.LIST_TYPE_LIST:
 			i = self.index(index)
 			orig = self.choices[i]


### PR DESCRIPTION
In choicesList & descriptionList, __len__(), __list__(), __iter__(),
behave as though the choices were ["", ""], but __getitem__() &
__setitem__() do not.

These changes allow the lists to be indexed with the index of "choice" 0,
even though it does not exist.

This fixes some crashes that were happening (reported in Satconfig) whe
ConfigSelection items were given empty choices lists in
ConfigSelection.setChoices().