### PR TITLE
[Wizard.py] Enable colour button activation

### DIFF
--- a/lib/python/Screens/Wizard.py
+++ b/lib/python/Screens/Wizard.py
@@ -242,19 +242,23 @@ class Wizard(Screen):
 
 	def red(self):
 # 		print "red"
-		pass
+		if self.wizard[self.currStep]["config"]["screen"] is not None and hasattr(self.configInstance, "red") and callable(self.configInstance.red):
+			self.configInstance.red()
 
 	def green(self):
 # 		print "green"
-		pass
+		if self.wizard[self.currStep]["config"]["screen"] is not None and hasattr(self.configInstance, "green") and callable(self.configInstance.green):
+			self.configInstance.green()
 
 	def yellow(self):
 # 		print "yellow"
-		pass
+		if self.wizard[self.currStep]["config"]["screen"] is not None and hasattr(self.configInstance, "yellow") and callable(self.configInstance.yellow):
+			self.configInstance.yellow()
 
 	def blue(self):
 # 		print "blue"
-		pass
+		if self.wizard[self.currStep]["config"]["screen"] is not None and hasattr(self.configInstance, "blue") and callable(self.configInstance.blue):
+			self.configInstance.blue()
 
 	def deleteForward(self):
 		self.resetCounter()


### PR DESCRIPTION
This change enables colour button methods in the config based screens to be used.  To enable the linkage simply add a "red()", "green()", "yellow()" and/or "blue()" method to the  Setup based screen and when the screen is instantiated by Wizard.py these functions can be found and used.
