### PR TITLE
Remove unused arguments to Time.py

### DIFF
--- a/data/startwizard.xml
+++ b/data/startwizard.xml
@@ -379,7 +379,7 @@ self.selectKey("OK")
 		<step id="timeoptions" nextstep="wizardoptions">
 			<text value="Please set your time options.\n\nPress YELLOW to set the time zone via geolocation." />
 			<displaytext value="Please set your time options" />
-			<config screen="Time" module="Time" args="time" type="ConfigList" />
+			<config screen="Time" module="Time" type="ConfigList" />
 			<code>
 self.clearSelectedKeys()
 self.selectKey("LEFT")

--- a/lib/python/Screens/Time.py
+++ b/lib/python/Screens/Time.py
@@ -6,8 +6,8 @@ from Tools.Geolocation import geolocation
 
 
 class Time(Setup):
-	def __init__(self, session, PluginLanguageDomain=None):
-		Setup.__init__(self, session=session, setup="time", plugin=None, PluginLanguageDomain=PluginLanguageDomain)
+	def __init__(self, session):
+		Setup.__init__(self, session=session, setup="time")
 		self["key_yellow"] = StaticText("")
 		self["geolocationActions"] = HelpableActionMap(self, "ColorActions", {
 			"yellow": (self.useGeolocation, _("Use geolocation to set the current time zone location"))


### PR DESCRIPTION
[Time.py] Remove plugin parameters
- Time.py is a core function and does not receive or use the plugin based arguments.

[startwizard.xml] Remove Time.py arguments
- Remove the arguments passed to Time.py as they are unused.
