### PR TITLE
[InfoBarGenerics.py] Correct forum reported crash

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -55,7 +55,7 @@ from Tools.KeyBindings import getKeyDescription, getKeyBindingKeys
 import NavigationInstance
 
 from enigma import eTimer, eServiceCenter, eDVBServicePMTHandler, iServiceInformation, iPlayableService, iRecordableService, eServiceReference, eEPGCache, eActionMap, getDesktop, eDVBDB
-from boxbranding import getBrandOEM, getMachineBrand, getMachineBuild, getMachineName
+from boxbranding import getMachineBrand, getMachineName
 from keyids import KEYFLAGS, KEYIDS, invertKeyIds
 
 from time import time, localtime, strftime

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -55,6 +55,7 @@ from Tools.KeyBindings import getKeyDescription, getKeyBindingKeys
 import NavigationInstance
 
 from enigma import eTimer, eServiceCenter, eDVBServicePMTHandler, iServiceInformation, iPlayableService, iRecordableService, eServiceReference, eEPGCache, eActionMap, getDesktop, eDVBDB
+from boxbranding import getBrandOEM, getMachineBrand, getMachineBuild, getMachineName
 from keyids import KEYFLAGS, KEYIDS, invertKeyIds
 
 from time import time, localtime, strftime


### PR DESCRIPTION
Fix crash reported in forum thread https://www.world-of-satellite.com/showthread.php?63350-5-4-001-037-PIP-crash.  Added the two missing boxbranding imports "getMachineBrand()" and "getMachineName()".  Remove the unused imports "getBrandOEM()" and "getMachineBuild()".
