### PR TITLE
[Time.py] Use "is" rather than "=="

### DIFF
--- a/lib/python/Screens/Time.py
+++ b/lib/python/Screens/Time.py
@@ -35,9 +35,9 @@ class Time(Setup):
 			areaItem = None
 			valItem = None
 			for item in self["config"].list:
-				if item[1] == config.timezone.area:
+				if item[1] is config.timezone.area:
 					areaItem = item
-				if item[1] == config.timezone.val:
+				if item[1] is config.timezone.val:
 					valItem = item
 			area, zone = tz.split("/", 1)
 			config.timezone.area.value = area


### PR DESCRIPTION
This is a suggested improvement from Prl.
