### PR TITLE
[Time.py] Save the geolocation acquired settings

### DIFF
--- a/lib/python/Screens/Time.py
+++ b/lib/python/Screens/Time.py
@@ -54,3 +54,4 @@ class Time(Setup):
 		self.selectionChanged()
 		self.useGeolocation()
 		self["config"].l.invalidate()
+		config.timezone.save()


### PR DESCRIPTION
This change ensures that the settings acquired by a geolocation lookup are saved to the settings file.  Without this the settings could be lost if there is a crash before the settings are saved.  Editing the time settings after the wizard is run would show that the settings have changed even though it appears that they have not changed.  Cancelling the settings change at this point will restore the initial factory default settings.
