### PR TITLE
[Setup.py] Remove legacy setupdom() method

### DIFF
--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -337,17 +337,6 @@ def setupDom(setup=None, plugin=None):
 		print("[Setup] Error %d: Unexpected error opening setup file '%s'! (%s)" % (err.errno, setupFile, err.strerror))
 	return setupFileDom
 
-# Temporary legacy interface.
-#
-def setupdom(plugin=None):
-	if plugin:
-		setupfile = file(resolveFilename(SCOPE_PLUGINS, pathJoin(plugin, "setup.xml")), "r")
-	else:
-		setupfile = file(resolveFilename(SCOPE_SKIN, "setup.xml"), "r")
-	setupfiledom = xml.etree.cElementTree.parse(setupfile)
-	setupfile.close()
-	return setupfiledom
-
 # Only used in AudioSelection screen...
 #
 def getConfigMenuItem(configElement):


### PR DESCRIPTION
This code was only used by the old versions of Recordings.py and Timeshift.py.  Now that the refactored version of those modules is now in use this support code can go.
