### PR TITLE
Clean up menu title processing

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -1,47 +1,55 @@
-<!--suppress XmlUnboundNsPrefix -->
-<menu text="Mainmenu" title="Main menu">
-	<id val="mainmenu"/>
-<!-- the following types are allowed:
-	<screen [module="mod"] [screen="classname"]>[arguments]</screen>
-		executes Screen called "classname" from module "Screen.mod"
-		if no module is given, Screen must be globally available.
-		if no screen is given, module is used as screen class name.
-		arguments must be comma seperated (will be fed to eval), and can
-			use stuff from module
-		(of course you must specify at least one of module, screen.)
-	<setup id="id"/>
-		opens a setup with specified id
-	<code> .. code .. </code>
-		"exec"s code-->
+<!-- suppress XmlUnboundNsPrefix -->
 
-<!-- Menu / Setup -->
-		<menu weight="1" text="Setup" flushConfigOnClose="1" entryID="setup_selection" >
-			<id val="setup"/>
-			<!-- Menu / Setup / AV -->
-			<menu weight="1" level="0" text="Audio &amp; video" entryID="av_setup">
-				<id val="av"/>
-				<item weight="1" text="Settings" entryID="av_setup"><screen module="VideoMode" screen="VideoSetup"/></item>
-				<item level="1" entryID="autolanguage_setup"><setup id="autolanguagesetup"/></item>
-			</menu>
-			<!-- Menu / Setup / Tuners -->
-			<menu weight="2" level="0" text="Tuners &amp; scanning" entryID="service_searching_selection">
-				<id val="scan"/>
-				<!-- Menu / Setup / Tuners / Settings -->
-				<item weight="1" text="Tuner setup" entryID="tuner_setup" requires="ClientModeDisabled"><screen module="Satconfig" screen="NimSelection"/></item>
-				<item weight="2" text="Tuner setup" entryID="client_mode" requires="ClientModeEnabled"><screen module="ClientMode" screen="ClientModeScreen"/></item>
-				<item weight="3" entryID="tunermisc_setup"><setup id="tunermisc"/></item>
-				<item weight="20" text="Automatic scan" entryID="auto_scan" conditional="nimmanager.somethingConnected()" requires="ClientModeDisabled"><screen module="ScanSetup" screen="ScanSimple"/></item>
-				<item weight="30" text="Manual scan" entryID="manual_scan" conditional="nimmanager.somethingConnected()" requires="ClientModeDisabled"><screen module="ScanSetup"/></item>
-				<item weight="100" text="Fallback configuration" entryID="fallback_mode" requires="ClientModeDisabled"><screen  module="FallbackTunerSetup" screen="FallbackTunerSetup"/></item>
-			</menu>
-			<!-- Menu / Setup / EPG -->
-			<menu weight="3" text="EPG" entryID="epg_menu">
-				<id val="epg"/>
-				<item level="0" entryID="epg_setup"><setup id="epgsettings"/></item>
-				<menu level="2" text="Load-save-delete" entryID="epgloadsave_menu">
-					<id val="epgloadsave_menu"/>
-					<item level="0" entryID="saveepgcache" text="Save EPG">
-<code>
+<!--
+	The following types are allowed:
+	<screen [module="mod"] [screen="classname"]>[arguments]</screen>
+		Executes Screen called "classname" from module "Screen.mod".
+		If no module is given, Screen must be globally available.
+		If no screen is given, module is used as screen class name.
+		Arguments must be comma seperated (will be fed to eval), and can
+			use stuff from module.
+		(Of course you must specify at least one of module, screen.)
+	<setup id="id" />
+		Opens a setup with specified id.
+	<code> .. code .. </code>
+		Python "exec"s code.
+-->
+
+<!-- Main Menu -->
+<menu entryID="main_menu" level="0" text="Main Menu">
+	<id val="mainmenu" />
+
+	<!-- Menu / Setup -->
+	<menu weight="1" text="Setup" flushConfigOnClose="1" entryID="setup_selection" >
+		<id val="setup" />
+
+		<!-- Menu / Setup / AV -->
+		<menu weight="1" level="0" text="Audio &amp; video" entryID="av_setup">
+			<id val="av" />
+			<item weight="1" text="Settings" entryID="av_setup"><screen module="VideoMode" screen="VideoSetup" /></item>
+			<item level="1" entryID="autolanguage_setup"><setup id="autolanguagesetup" /></item>
+		</menu>
+
+		<!-- Menu / Setup / Tuners -->
+		<menu weight="2" level="0" text="Tuners &amp; scanning" entryID="service_searching_selection">
+			<id val="scan" />
+			<!-- Menu / Setup / Tuners / Settings -->
+			<item weight="1" text="Tuner setup" entryID="tuner_setup" requires="ClientModeDisabled"><screen module="Satconfig" screen="NimSelection" /></item>
+			<item weight="2" text="Tuner setup" entryID="client_mode" requires="ClientModeEnabled"><screen module="ClientMode" screen="ClientModeScreen" /></item>
+			<item weight="3" entryID="tunermisc_setup"><setup id="tunermisc" /></item>
+			<item weight="20" text="Automatic scan" entryID="auto_scan" conditional="nimmanager.somethingConnected()" requires="ClientModeDisabled"><screen module="ScanSetup" screen="ScanSimple" /></item>
+			<item weight="30" text="Manual scan" entryID="manual_scan" conditional="nimmanager.somethingConnected()" requires="ClientModeDisabled"><screen module="ScanSetup" /></item>
+			<item weight="100" text="Fallback configuration" entryID="fallback_mode" requires="ClientModeDisabled"><screen  module="FallbackTunerSetup" screen="FallbackTunerSetup" /></item>
+		</menu>
+
+		<!-- Menu / Setup / EPG -->
+		<menu weight="3" text="EPG" entryID="epg_menu">
+			<id val="epg" />
+			<item level="0" entryID="epg_setup"><setup id="epgsettings" /></item>
+			<menu level="2" text="Load-save-delete" entryID="epgloadsave_menu">
+				<id val="epgloadsave_menu" />
+				<item level="0" entryID="saveepgcache" text="Save EPG">
+					<code>
 from Components.EpgLoadSave import EpgSaveMsg
 def msgClosed(ret):
 	if ret:
@@ -49,10 +57,10 @@ def msgClosed(ret):
 		epgcache = eEPGCache.getInstance()
 		epgcache.save()
 self.session.openWithCallback(msgClosed, EpgSaveMsg)
-</code>
-					</item>
-					<item level="0" entryID="loadepgcache" text="Load EPG">
-<code>
+					</code>
+				</item>
+				<item level="0" entryID="loadepgcache" text="Load EPG">
+					<code>
 from Components.EpgLoadSave import EpgLoadMsg
 def msgClosed(ret):
 	if ret:
@@ -60,10 +68,10 @@ def msgClosed(ret):
 		epgcache = eEPGCache.getInstance()
 		epgcache.load()
 self.session.openWithCallback(msgClosed, EpgLoadMsg)
-</code>
-					</item>
-					<item level="0" entryID="deleteepgcache" text="Delete EPG">
-<code>
+					</code>
+				</item>
+				<item level="0" entryID="deleteepgcache" text="Delete EPG">
+					<code>
 from Components.EpgLoadSave import EpgDeleteMsg
 def msgClosed(ret):
 	if ret:
@@ -75,168 +83,171 @@ def msgClosed(ret):
 		epgcache = eEPGCache.getInstance()
 		epgcache.flushEPG()
 self.session.openWithCallback(msgClosed, EpgDeleteMsg)
-</code>
-					</item>
-				</menu>
-				<item level="2" entryID="setup_epgsingle"><setup id="epgsingle"/></item>
-				<item level="2" entryID="setup_epggrid"><setup id="epggrid"/></item>
-				<item level="2" entryID="setup_epginfobarsingle"><setup id="epginfobarsingle"/></item>
-				<item level="2" entryID="setup_epginfobargrid"><setup id="epginfobargrid"/></item>
-				<item level="2" entryID="setup_epgmulti"><setup id="epgmulti"/></item>
+					</code>
+				</item>
 			</menu>
-			<!-- Menu / Setup / User Interface -->
-			<menu weight="4" text="User interface" entryID="osd_setup" requires="OsdMenu">
-				<id val="osd_menu"/>
-				<!-- Menu / Setup / User Interface / Settings -->
-				<item weight="1" entryID="user_interface"><setup id="userinterface"/></item>
-				<!-- Menu / Setup / User Interface / Channel Selection settings -->
-				<item weight="2" level="0" entryID="channelselection_setup"><setup id="channelselection"/></item>
-				<!-- Menu / Setup / User Interface / Skin Setup -->
-				<menu weight="3" level="0" text="Skin setup" entryID="gui_skin" requires="OsdMenu">
-					<id val="skinsetup"/>
-					<item weight="1" level="0" text="Skin" entryID="skin_setup"><screen module="SkinSelector" screen="SkinSelector"/></item>
-					<item level="2" text="3D" entryID="osd3dsetup" requires="CanChange3DOsd"><screen module="UserInterfacePositioner" screen="OSD3DSetupScreen"/></item>
-					<item level="2" text="OSD position" entryID="osdsetup" requires="OsdSetup"><screen module="UserInterfacePositioner" screen="UserInterfacePositioner"/></item>
-				</menu>
-				<!-- Menu / Setup / User Interface / Front Panel -->
-				<menu weight="4" level="0" text="Front panel display" entryID="display_selection" requires="Display">
-					<id val="display"/>
-					<item weight="1" level="0" text="Settings" entryID="display_setup"><setup id="display"/></item>
-					<item weight="2" level="0" text="Skin" entryID="lcd_skin_setup" requires="LCDSKINSetup"><screen module="SkinSelector" screen="LcdSkinSelector"/></item>
-				</menu>
-				<!-- Menu / Setup / User Interface / LED Display -->
-				<menu weight="5" level="0" text="LED display panel" entryID="leddisplay_selection" requires="DisplayLED">
-					<id val="leddisplay"/>
-				</menu>
-				<!-- Menu / Setup / User Interface / Button Setup -->
-				<item weight="6" level="2" text="Button setup" entryID="buttonsetup_setup"><screen module="ButtonSetup" screen="ButtonSetup"/></item>
-				<!-- Menu / Setup / User Interface / Subtitles -->
-				<item weight="7" level="2" entryID="subtitle_setup"><setup id="subtitlesetup"/></item>
-				<!-- Menu / Setup / User Interface / Language Selection -->
-				<item weight="8" level="0" text="Language" entryID="language_setup"><screen module="LanguageSelection"/></item>
-				<!-- Menu / Setup / User Interface / Parental Control -->
-				<item weight="9" level="0" text="Parental control" entryID="parental_setup"><screen module="ParentalControlSetup" screen="ParentalControlSetup"/></item>
+			<item level="2" entryID="setup_epgsingle"><setup id="epgsingle" /></item>
+			<item level="2" entryID="setup_epggrid"><setup id="epggrid" /></item>
+			<item level="2" entryID="setup_epginfobarsingle"><setup id="epginfobarsingle" /></item>
+			<item level="2" entryID="setup_epginfobargrid"><setup id="epginfobargrid" /></item>
+			<item level="2" entryID="setup_epgmulti"><setup id="epgmulti" /></item>
+		</menu>
+
+		<!-- Menu / Setup / User Interface -->
+		<menu weight="4" text="User interface" entryID="osd_setup" requires="OsdMenu">
+			<id val="osd_menu" />
+			<!-- Menu / Setup / User Interface / Settings -->
+			<item weight="1" entryID="user_interface"><setup id="userinterface" /></item>
+			<!-- Menu / Setup / User Interface / Channel Selection settings -->
+			<item weight="2" level="0" entryID="channelselection_setup"><setup id="channelselection" /></item>
+			<!-- Menu / Setup / User Interface / Skin Setup -->
+			<menu weight="3" level="0" text="Skin setup" entryID="gui_skin" requires="OsdMenu">
+				<id val="skinsetup" />
+				<item weight="1" level="0" text="Skin" entryID="skin_setup"><screen module="SkinSelector" screen="SkinSelector" /></item>
+				<item level="2" text="3D" entryID="osd3dsetup" requires="CanChange3DOsd"><screen module="UserInterfacePositioner" screen="OSD3DSetupScreen" /></item>
+				<item level="2" text="OSD position" entryID="osdsetup" requires="OsdSetup"><screen module="UserInterfacePositioner" screen="UserInterfacePositioner" /></item>
 			</menu>
-			<!-- Menu / Setup / Network -->
-			<menu weight="5" text="Network" entryID="network_menu">
-				<id val="network"/>
-				<!-- Menu / Setup / Network / Device -->
-				<item weight="1" level="0" text="Device" entryID="device_setup"><screen module="NetworkSetup" screen="NetworkAdapterSelection"/></item>
-				<!-- Menu / Setup / Network / Mounts -->
-				<item weight="2" level="1" text="Mounts" entryID="netmounts_setup"><screen module="NetworkSetup" screen="NetworkMountsMenu"/></item>
-				<!-- Menu / Setup / Network / Utilities -->
-				<menu weight="3" level="0" text="Utilities" entryID="services_menu">
-					<id val="netservices"/>
-					<item level="2" text="AFP" entryID="netafp_setup"><screen module="NetworkSetup" screen="NetworkAfp"/></item>
-					<item level="2" text="FTP" entryID="netftp_setup"><screen module="NetworkSetup" screen="NetworkFtp"/></item>
-					<item level="2" text="Inadyn" entryID="Inadyn_setup"><screen module="NetworkSetup" screen="NetworkInadyn"/></item>
-					<item level="2" text="MiniDLNA" entryID="netdlna_setup"><screen module="NetworkSetup" screen="NetworkMiniDLNA"/></item>
-					<item level="2" text="NFS" entryID="netnfs_setup"><screen module="NetworkSetup" screen="NetworkNfs"/></item>
-					<item level="2" text="OpenVPN" entryID="netvpn_setup"><screen module="NetworkSetup" screen="NetworkOpenvpn"/></item>
-					<item level="2" text="SABnzbd" entryID="netsabnzbd_setup" requires="SABSetup">
-<code>
+			<!-- Menu / Setup / User Interface / Front Panel -->
+			<menu weight="4" level="0" text="Front panel display" entryID="display_selection" requires="Display">
+				<id val="display" />
+				<item weight="1" level="0" text="Settings" entryID="display_setup"><setup id="display" /></item>
+				<item weight="2" level="0" text="Skin" entryID="lcd_skin_setup" requires="LCDSKINSetup"><screen module="SkinSelector" screen="LcdSkinSelector" /></item>
+			</menu>
+			<!-- Menu / Setup / User Interface / LED Display -->
+			<menu weight="5" level="0" text="LED display panel" entryID="leddisplay_selection" requires="DisplayLED">
+				<id val="leddisplay" />
+			</menu>
+			<!-- Menu / Setup / User Interface / Button Setup -->
+			<item weight="6" level="2" text="Button setup" entryID="buttonsetup_setup"><screen module="ButtonSetup" screen="ButtonSetup" /></item>
+			<!-- Menu / Setup / User Interface / Subtitles -->
+			<item weight="7" level="2" entryID="subtitle_setup"><setup id="subtitlesetup" /></item>
+			<!-- Menu / Setup / User Interface / Language Selection -->
+			<item weight="8" level="0" text="Language" entryID="language_setup"><screen module="LanguageSelection" /></item>
+			<!-- Menu / Setup / User Interface / Parental Control -->
+			<item weight="9" level="0" text="Parental control" entryID="parental_setup"><screen module="ParentalControlSetup" screen="ParentalControlSetup" /></item>
+		</menu>
+
+		<!-- Menu / Setup / Network -->
+		<menu weight="5" text="Network" entryID="network_menu">
+			<id val="network" />
+			<!-- Menu / Setup / Network / Device -->
+			<item weight="1" level="0" text="Device" entryID="device_setup"><screen module="NetworkSetup" screen="NetworkAdapterSelection" /></item>
+			<!-- Menu / Setup / Network / Mounts -->
+			<item weight="2" level="1" text="Mounts" entryID="netmounts_setup"><screen module="NetworkSetup" screen="NetworkMountsMenu" /></item>
+			<!-- Menu / Setup / Network / Utilities -->
+			<menu weight="3" level="0" text="Utilities" entryID="services_menu">
+				<id val="netservices" />
+				<item level="2" text="AFP" entryID="netafp_setup"><screen module="NetworkSetup" screen="NetworkAfp" /></item>
+				<item level="2" text="FTP" entryID="netftp_setup"><screen module="NetworkSetup" screen="NetworkFtp" /></item>
+				<item level="2" text="Inadyn" entryID="Inadyn_setup"><screen module="NetworkSetup" screen="NetworkInadyn" /></item>
+				<item level="2" text="MiniDLNA" entryID="netdlna_setup"><screen module="NetworkSetup" screen="NetworkMiniDLNA" /></item>
+				<item level="2" text="NFS" entryID="netnfs_setup"><screen module="NetworkSetup" screen="NetworkNfs" /></item>
+				<item level="2" text="OpenVPN" entryID="netvpn_setup"><screen module="NetworkSetup" screen="NetworkOpenvpn" /></item>
+				<item level="2" text="SABnzbd" entryID="netsabnzbd_setup" requires="SABSetup">
+					<code>
 from Plugins.SystemPlugins.SABnzbd.plugin import SABnzbdSetupScreen
 self.session.open(SABnzbdSetupScreen)
-</code>
-					</item>
-					<item level="2" text="Samba" entryID="netsmba_setup"><screen module="NetworkSetup" screen="NetworkSamba"/></item>
-					<item level="2" text="Telnet" entryID="nettelnet_setup"><screen module="NetworkSetup" screen="NetworkTelnet"/></item>
-					<item level="2" text="uShare" entryID="netushare_setup"><screen module="NetworkSetup" screen="NetworkuShare"/></item>
-				</menu>
-				<!-- Menu / Setup / Network / Password -->
-				<item level="2" text="Password" entryID="password_setup"><screen module="NetworkSetup" screen="NetworkPassword"/></item>
+					</code>
+				</item>
+				<item level="2" text="Samba" entryID="netsmba_setup"><screen module="NetworkSetup" screen="NetworkSamba" /></item>
+				<item level="2" text="Telnet" entryID="nettelnet_setup"><screen module="NetworkSetup" screen="NetworkTelnet" /></item>
+				<item level="2" text="uShare" entryID="netushare_setup"><screen module="NetworkSetup" screen="NetworkuShare" /></item>
 			</menu>
-			<!-- Menu / Setup / Common Interface -->
-			<menu weight="7" text="Common interface" entryID="cicam_setup" requires="CommonInterface">
-				<id val="cicam"/>
-				<item weight="10" level="1" text="Common interface" entryID="ci_setup"><screen module="Ci" screen="CiSelection"/></item>
+			<!-- Menu / Setup / Network / Password -->
+			<item level="2" text="Password" entryID="password_setup"><screen module="NetworkSetup" screen="NetworkPassword" /></item>
+		</menu>
+		<!-- Menu / Setup / Common Interface -->
+		<menu weight="7" text="Common interface" entryID="cicam_setup" requires="CommonInterface">
+			<id val="cicam" />
+			<item weight="10" level="1" text="Common interface" entryID="ci_setup"><screen module="Ci" screen="CiSelection" /></item>
+		</menu>
+		<!-- Menu / Setup / Softcam -->
+		<menu weight="8" text="Softcam" entryID="cam_setup">
+			<id val="cam" />
+			<item weight="1" level="2" text="Settings" entryID="softcam_setup"><setup id="softcamsetup" /></item>
+			<item weight="98" level="2" text="CCcam info" entryID="cccaminfo" requires="CCcamInstalled"><screen module="CCcamInfo" screen="CCcamInfoMain" /></item>
+			<item weight="99" level="2" text="OScam info" entryID="oscaminfo" requires="OScamInstalled"><screen module="OScamInfo" screen="OscamInfoMenu" /></item>
+		</menu>
+		<!-- Menu / Setup / Storage -->
+		<menu weight="9" level="0" text="Storage" entryID="hardisk_selection" requires="Harddisk">
+			<id val="harddisk" />
+			<item level="1" text="Settings" entryID="harddisk_setup"><setup id="harddisk" /></item>
+			<item level="0" text="Initialize devices" entryID="harddisk_init"><screen module="HarddiskSetup" screen="HarddiskSelection" /></item>
+			<item level="0" text="Filesystem check" entryID="harddisk_check"><screen module="HarddiskSetup" screen="HarddiskFsckSelection" /></item>
+		</menu>
+		<!-- Menu / Setup / Time Settings -->
+		<item level="0" text="Time" entryID="time_setup"><screen module="Time" screen="Time" /></item>
+		<!-- Menu / Setup / Recordings, Playback & Timeshift -->
+		<menu weight="11" level="1" text="Recordings, playback &amp; timeshift" entryID="rec_setup">
+			<id val="rec" />
+				<item weight="10" level="0" text="Timeshift" entryID="timshift_setup"><screen module="Timeshift" screen="TimeshiftSettings" /></item>
+				<item weight="15" level="0" text="Recording &amp; playback" entryID="recording_setup"><screen module="Recordings" screen="RecordingSettings" /></item>
+		</menu>
+		<!-- Menu / Setup / System (OLD SYSTEM ENTRY FOR COMPATIBILITY) -->
+		<menu weight="98" level="0" text="System" entryID="system_selection">
+			<id val="system" />
+			<!-- Menu / Setup / System / Logs -->
+			<item weight="1" entryID="usage_setup"><setup id="usage" /></item>
+			<menu weight="2" level="2" text="Logs" entryID="logs_setup">
+				<id val="logs_menu" />
+				<item level="2" text="Settings" entryID="logs_setup"><setup id="logs" /></item>
+				<item level="2" text="Log manager" entryID="logs_man"><screen module="LogManager" screen="LogManager" /></item>
 			</menu>
-			<!-- Menu / Setup / Softcam -->
-			<menu weight="8" text="Softcam" entryID="cam_setup">
-				<id val="cam"/>
-				<item weight="1" level="2" text="Settings" entryID="softcam_setup"><setup id="softcamsetup"/></item>
-				<item weight="98" level="2" text="CCcam info" entryID="cccaminfo" requires="CCcamInstalled"><screen module="CCcamInfo" screen="CCcamInfoMain"/></item>
-				<item weight="99" level="2" text="OScam info" entryID="oscaminfo" requires="OScamInstalled"><screen module="OScamInfo" screen="OscamInfoMenu"/></item>
-			</menu>
-			<!-- Menu / Setup / Storage -->
-			<menu weight="9" level="0" text="Storage" entryID="hardisk_selection" requires="Harddisk">
-				<id val="harddisk"/>
-				<item level="1" text="Settings" entryID="harddisk_setup"><setup id="harddisk"/></item>
-				<item level="0" text="Initialize devices" entryID="harddisk_init"><screen module="HarddiskSetup" screen="HarddiskSelection"/></item>
-				<item level="0" text="Filesystem check" entryID="harddisk_check"><screen module="HarddiskSetup" screen="HarddiskFsckSelection"/></item>
-			</menu>
-			<!-- Menu / Setup / Time Settings -->
-			<item level="0" text="Time" entryID="time_setup"><screen module="Time" screen="Time" /></item>
-			<!-- Menu / Setup / Recordings, Playback & Timeshift -->
-			<menu weight="11" level="1" text="Recordings, playback &amp; timeshift" entryID="rec_setup">
-			 	<id val="rec" />
-					<item weight="10" level="0" text="Timeshift" entryID="timshift_setup"><screen module="Timeshift" screen="TimeshiftSettings" /></item>
-					<item weight="15" level="0" text="Recording &amp; playback" entryID="recording_setup"><screen module="Recordings" screen="RecordingSettings" /></item>
-			</menu>
-			<!-- Menu / Setup / System (OLD SYSTEM ENTRY FOR COMPATIBILITY) -->
-			<menu weight="98" level="0" text="System" entryID="system_selection">
-				<id val="system"/>
-				<!-- Menu / Setup / System / Logs -->
-				<item weight="1" entryID="usage_setup"><setup id="usage"/></item>
-				<menu weight="2" level="2" text="Logs" entryID="logs_setup">
-					<id val="logs_menu"/>
-					<item level="2" text="Settings" entryID="logs_setup"><setup id="logs"/></item>
-					<item level="2" text="Log manager" entryID="logs_man"><screen module="LogManager" screen="LogManager"/></item>
-				</menu>
-				<!-- Menu / Setup / System / Input Devices -->
-				<item weight="3" level="1" text="Input devices" entryID="input_device_setup"><screen module="InputDeviceSetup" screen="InputDeviceSelection"/></item>
-				<!-- Menu / Setup / System / Keyboard Setup -->
-				<item weight="4" entryID="keyboard_setup" text="Keyboard"><setup id="keyboard"/></item>
-				<!-- Menu / Setup / System / RF Setup -->
-				<item weight="5" level="1" entryID="rfmod_setup" requires="RfModulator"><setup id="RFmod"/></item>
-				<!-- Menu / Setup / System / Factory Reset -->
-				<item weight="99" level="0" text="Factory reset" entryID="factory_reset"><screen module="FactoryReset" screen="FactoryReset"/></item>
-				<item weight="2" level="0" text="Software update" entryID="software_update"><screen module="SoftwareUpdate" screen="UpdatePlugin"/></item>
-			</menu>
-			<!-- Menu / Setup / HDMI-CEC -->
-			<item weight="99" text="HDMI CEC" entryID="hdmicec" requires="HDMICEC">
-<code>
+			<!-- Menu / Setup / System / Input Devices -->
+			<item weight="3" level="1" text="Input devices" entryID="input_device_setup"><screen module="InputDeviceSetup" screen="InputDeviceSelection" /></item>
+			<!-- Menu / Setup / System / Keyboard Setup -->
+			<item weight="4" entryID="keyboard_setup" text="Keyboard"><setup id="keyboard" /></item>
+			<!-- Menu / Setup / System / RF Setup -->
+			<item weight="5" level="1" entryID="rfmod_setup" requires="RfModulator"><setup id="RFmod" /></item>
+			<!-- Menu / Setup / System / Factory Reset -->
+			<item weight="99" level="0" text="Factory reset" entryID="factory_reset"><screen module="FactoryReset" screen="FactoryReset" /></item>
+			<item weight="2" level="0" text="Software update" entryID="software_update"><screen module="SoftwareUpdate" screen="UpdatePlugin" /></item>
+		</menu>
+		<!-- Menu / Setup / HDMI-CEC -->
+		<item weight="99" text="HDMI CEC" entryID="hdmicec" requires="HDMICEC">
+			<code>
 from Plugins.SystemPlugins.HdmiCEC.plugin import HdmiCECSetupScreen
 self.session.open(HdmiCECSetupScreen)
-</code>
-			</item>
-		</menu>
-<!-- Menu / Plugins -->
-		<item weight="2" text="Plugins" entryID="plugin_selection"><screen module="PluginBrowser" screen="PluginBrowser"/></item>
+			</code>
+		</item>
+	</menu>
 
-<!-- Menu / Timers -->
-		<menu weight="5" text="Timers" entryID="timer_menu">
-			<id val="timermenu"/>
-			<item weight="1" level="0" text="Timers" entryID="timer_edit"><screen module="TimerEdit" screen="TimerEditList"/></item>
-			<item weight="100" level="0" text="Cron timers" entryID="crontimer_edit"><screen module="CronTimer" screen="CronTimers"/></item>
-			<item weight="100" level="0" text="Power timers" entryID="powertimer_edit"><screen module="PowerTimerEdit" screen="PowerTimerEditList"/></item>
-		</menu>
+	<!-- Menu / Plugins -->
+	<item weight="2" text="Plugins" entryID="plugin_selection"><screen module="PluginBrowser" screen="PluginBrowser" /></item>
 
-<!-- Menu / Information -->
-		<menu weight="6" text="Information" entryID="info_screen">
-			<id val="information"/>
-			<item level="0" text="About" entryID="about_screen"><screen module="About" screen="About"/></item>
-			<item level="0" text="Devices" entryID="device_screen"><screen module="About" screen="Devices"/></item>
-			<item level="0" text="Memory" entryID="memory_screen"><screen module="About" screen="SystemMemoryInfo"/></item>
-			<item level="0" text="Network" entryID="network_screen"><screen module="About" screen="SystemNetworkInfo"/></item>
-			<item level="1" text="Service" entryID="service_info_screen"><screen module="ServiceInfo" screen="ServiceInfo"/></item>
-			<item level="2" text="Streaming clients" entryID="streaming_clients_info_screen"><screen module="StreamingClientsInfo"/></item>
-		</menu>
+	<!-- Menu / Timers -->
+	<menu weight="5" text="Timers" entryID="timer_menu">
+		<id val="timermenu" />
+		<item weight="1" level="0" text="Timers" entryID="timer_edit"><screen module="TimerEdit" screen="TimerEditList" /></item>
+		<item weight="100" level="0" text="Cron timers" entryID="crontimer_edit"><screen module="CronTimer" screen="CronTimers" /></item>
+		<item weight="100" level="0" text="Power timers" entryID="powertimer_edit"><screen module="PowerTimerEdit" screen="PowerTimerEditList" /></item>
+	</menu>
 
-<!-- Menu / VCR Scart -->
-		<item weight="7" text="VCR scart" entryID="scart_switch" conditional="config.usage.show_vcr_scart.value" requires="ScartSwitch"><code>self.session.scart.VCRSbChanged(3)</code></item>
+	<!-- Menu / Information -->
+	<menu weight="6" text="Information" entryID="info_screen">
+		<id val="information" />
+		<item level="0" text="About" entryID="about_screen"><screen module="About" screen="About" /></item>
+		<item level="0" text="Devices" entryID="device_screen"><screen module="About" screen="Devices" /></item>
+		<item level="0" text="Memory" entryID="memory_screen"><screen module="About" screen="SystemMemoryInfo" /></item>
+		<item level="0" text="Network" entryID="network_screen"><screen module="About" screen="SystemNetworkInfo" /></item>
+		<item level="1" text="Service" entryID="service_info_screen"><screen module="ServiceInfo" screen="ServiceInfo" /></item>
+		<item level="2" text="Streaming clients" entryID="streaming_clients_info_screen"><screen module="StreamingClientsInfo" /></item>
+	</menu>
 
-<!-- Menu / Standby and Restart -->
-		<menu weight="99" text="Standby and Restart" entryID="standby_restart_list">
-			<id val="shutdown"/>
-			<item text="Standby" entryID="standby"><screen module="Standby" screen="Standby"/></item>
-			<item text="Restart GUI" entryID="restart_enigma"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
-			<item text="Reboot" entryID="restart"><screen module="Standby" screen="TryQuitMainloop">2</screen></item>
-			<item text="Multiboot Image Selector" entryID="multiboot" requires="canMultiBoot"><screen module="MultiBootSelector" screen="MultiBootSelector">1</screen></item>
-			<item text="H9SDroot" entryID="H9SDswap" requires="HasH9SD"><screen module="H9SDswap" screen="H9SDswap">1</screen></item>
-			<item text="Deep standby" requires="DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
-			<item text="Shut down" requires="!DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
-			<item text="Recovery mode" requires="RecoveryMode" entryID="maintenance_mode"><screen module="Standby" screen="TryQuitMainloop">16</screen></item>
-			<item text="Android mode" requires="AndroidMode" entryID="android_mode"><screen module="Standby" screen="TryQuitMainloop">12</screen></item>
-		</menu>
+	<!-- Menu / VCR Scart -->
+	<item weight="7" text="VCR scart" entryID="scart_switch" conditional="config.usage.show_vcr_scart.value" requires="ScartSwitch"><code>self.session.scart.VCRSbChanged(3)</code></item>
+
+	<!-- Menu / Standby and Restart -->
+	<menu weight="99" text="Standby and Restart" entryID="standby_restart_list">
+		<id val="shutdown" />
+		<item text="Standby" entryID="standby"><screen module="Standby" screen="Standby" /></item>
+		<item text="Restart GUI" entryID="restart_enigma"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
+		<item text="Reboot" entryID="restart"><screen module="Standby" screen="TryQuitMainloop">2</screen></item>
+		<item text="Multiboot Image Selector" entryID="multiboot" requires="canMultiBoot"><screen module="MultiBootSelector" screen="MultiBootSelector">1</screen></item>
+		<item text="H9SDroot" entryID="H9SDswap" requires="HasH9SD"><screen module="H9SDswap" screen="H9SDswap">1</screen></item>
+		<item text="Deep standby" requires="DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
+		<item text="Shut down" requires="!DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
+		<item text="Recovery mode" requires="RecoveryMode" entryID="maintenance_mode"><screen module="Standby" screen="TryQuitMainloop">16</screen></item>
+		<item text="Android mode" requires="AndroidMode" entryID="android_mode"><screen module="Standby" screen="TryQuitMainloop">12</screen></item>
+	</menu>
 </menu>

--- a/data/menu.xml
+++ b/data/menu.xml
@@ -20,35 +20,34 @@
 	<id val="mainmenu" />
 
 	<!-- Menu / Setup -->
-	<menu weight="1" text="Setup" flushConfigOnClose="1" entryID="setup_selection" >
+	<menu entryID="setup_selection" level="0" text="Setup" flushConfigOnClose="1" weight="1">
 		<id val="setup" />
 
 		<!-- Menu / Setup / AV -->
-		<menu weight="1" level="0" text="Audio &amp; video" entryID="av_setup">
+		<menu entryID="av_setup" level="0" text="Audio &amp; Video" weight="1">
 			<id val="av" />
-			<item weight="1" text="Settings" entryID="av_setup"><screen module="VideoMode" screen="VideoSetup" /></item>
-			<item level="1" entryID="autolanguage_setup" text="Automatic Language"><setup id="autolanguagesetup" /></item>
+			<item entryID="av_setup" level="0" text="Settings" weight="1"><screen module="VideoMode" screen="VideoSetup" /></item>
+			<item entryID="autolanguage_setup" level="1" text="Automatic Language"><setup id="autolanguagesetup" /></item>
 		</menu>
 
 		<!-- Menu / Setup / Tuners -->
-		<menu weight="2" level="0" text="Tuners &amp; scanning" entryID="service_searching_selection">
+		<menu entryID="service_searching_selection" level="0" text="Tuners &amp; Scanning" weight="2">
 			<id val="scan" />
-			<!-- Menu / Setup / Tuners / Settings -->
-			<item weight="1" text="Tuner setup" entryID="tuner_setup" requires="ClientModeDisabled"><screen module="Satconfig" screen="NimSelection" /></item>
-			<item weight="2" text="Tuner setup" entryID="client_mode" requires="ClientModeEnabled"><screen module="ClientMode" screen="ClientModeScreen" /></item>
-			<item weight="3" entryID="tunermisc_setup" text="Miscellaneous"><setup id="tunermisc" /></item>
-			<item weight="20" text="Automatic scan" entryID="auto_scan" conditional="nimmanager.somethingConnected()" requires="ClientModeDisabled"><screen module="ScanSetup" screen="ScanSimple" /></item>
-			<item weight="30" text="Manual scan" entryID="manual_scan" conditional="nimmanager.somethingConnected()" requires="ClientModeDisabled"><screen module="ScanSetup" /></item>
-			<item weight="100" text="Fallback configuration" entryID="fallback_mode" requires="ClientModeDisabled"><screen  module="FallbackTunerSetup" screen="FallbackTunerSetup" /></item>
+			<item entryID="tuner_setup" level="0" text="Tuner Setup" weight="1" requires="ClientModeDisabled"><screen module="Satconfig" screen="NimSelection" /></item>
+			<item entryID="client_mode" level="0" text="Tuner Setup" weight="2" requires="ClientModeEnabled"><screen module="ClientMode" screen="ClientModeScreen" /></item>
+			<item entryID="tunermisc_setup" level="0" text="Miscellaneous" weight="3"><setup id="tunermisc" /></item>
+			<item entryID="auto_scan" level="0" text="Automatic Scan" weight="20" conditional="nimmanager.somethingConnected()" requires="ClientModeDisabled"><screen module="ScanSetup" screen="ScanSimple" /></item>
+			<item entryID="manual_scan" level="0" text="Manual Scan" weight="30" conditional="nimmanager.somethingConnected()" requires="ClientModeDisabled"><screen module="ScanSetup" /></item>
+			<item entryID="fallback_mode" level="0" text="Fallback Configuration" weight="100" requires="ClientModeDisabled"><screen module="FallbackTunerSetup" screen="FallbackTunerSetup" /></item>
 		</menu>
 
 		<!-- Menu / Setup / EPG -->
-		<menu weight="3" text="EPG" entryID="epg_menu">
+		<menu entryID="epg_menu" level="0" text="EPG" weight="3">
 			<id val="epg" />
-			<item level="0" entryID="epg_setup" text="Settings"><setup id="epgsettings" /></item>
-			<menu level="2" text="Load-save-delete" entryID="epgloadsave_menu">
+			<item entryID="epg_setup" level="0" text="Settings"><setup id="epgsettings" /></item>
+			<menu entryID="epgloadsave_menu" level="2" text="Load, Save &amp; Delete EPG Cache">
 				<id val="epgloadsave_menu" />
-				<item level="0" entryID="saveepgcache" text="Save EPG Cache">
+				<item entryID="saveepgcache" level="0" text="Save EPG Cache">
 					<code>
 from Components.EpgLoadSave import EpgSaveMsg
 def msgClosed(ret):
@@ -59,7 +58,7 @@ def msgClosed(ret):
 self.session.openWithCallback(msgClosed, EpgSaveMsg)
 					</code>
 				</item>
-				<item level="0" entryID="loadepgcache" text="Load EPG Cache">
+				<item entryID="loadepgcache" level="0" text="Load EPG Cache">
 					<code>
 from Components.EpgLoadSave import EpgLoadMsg
 def msgClosed(ret):
@@ -70,7 +69,7 @@ def msgClosed(ret):
 self.session.openWithCallback(msgClosed, EpgLoadMsg)
 					</code>
 				</item>
-				<item level="0" entryID="deleteepgcache" text="Delete EPG Cache">
+				<item entryID="deleteepgcache" level="0" text="Delete EPG Cache">
 					<code>
 from Components.EpgLoadSave import EpgDeleteMsg
 def msgClosed(ret):
@@ -86,125 +85,114 @@ self.session.openWithCallback(msgClosed, EpgDeleteMsg)
 					</code>
 				</item>
 			</menu>
-			<item level="2" entryID="setup_epgsingle" text="Single EPG"><setup id="epgsingle" /></item>
-			<item level="2" entryID="setup_epggrid" text="Grid EPG"><setup id="epggrid" /></item>
-			<item level="2" entryID="setup_epginfobarsingle" text="Infobar Single EPG"><setup id="epginfobarsingle" /></item>
-			<item level="2" entryID="setup_epginfobargrid" text="Infobar Grid EPG"><setup id="epginfobargrid" /></item>
-			<item level="2" entryID="setup_epgmulti" text="Multi EPG"><setup id="epgmulti" /></item>
+			<item entryID="setup_epgsingle" level="2" text="Single EPG"><setup id="epgsingle" /></item>
+			<item entryID="setup_epggrid" level="2" text="Grid EPG"><setup id="epggrid" /></item>
+			<item entryID="setup_epginfobarsingle" level="2" text="Infobar Single EPG"><setup id="epginfobarsingle" /></item>
+			<item entryID="setup_epginfobargrid" level="2" text="Infobar Grid EPG"><setup id="epginfobargrid" /></item>
+			<item entryID="setup_epgmulti" level="2" text="Multi EPG"><setup id="epgmulti" /></item>
 		</menu>
 
 		<!-- Menu / Setup / User Interface -->
-		<menu weight="4" text="User interface" entryID="osd_setup" requires="OsdMenu">
+		<menu entryID="osd_setup" level="0" text="User Interface" weight="4" requires="OsdMenu">
 			<id val="osd_menu" />
-			<!-- Menu / Setup / User Interface / Settings -->
-			<item weight="1" entryID="user_interface" text="Settings"><setup id="userinterface" /></item>
-			<!-- Menu / Setup / User Interface / Channel Selection settings -->
-			<item weight="2" level="0" entryID="channelselection_setup" text="Channel Selection"><setup id="channelselection" /></item>
-			<!-- Menu / Setup / User Interface / Skin Setup -->
-			<menu weight="3" level="0" text="Skin setup" entryID="gui_skin" requires="OsdMenu">
+			<item entryID="user_interface" level="0" text="Settings" weight="1"><setup id="userinterface" /></item>
+			<item entryID="channelselection_setup" level="0" text="Channel Selection" weight="2"><setup id="channelselection" /></item>
+			<menu entryID="gui_skin" level="0" text="Skin Setup" weight="3" requires="OsdMenu">
 				<id val="skinsetup" />
-				<item weight="1" level="0" text="Skin" entryID="skin_setup"><screen module="SkinSelector" screen="SkinSelector" /></item>
-				<item level="2" text="3D" entryID="osd3dsetup" requires="CanChange3DOsd"><screen module="UserInterfacePositioner" screen="OSD3DSetupScreen" /></item>
-				<item level="2" text="OSD position" entryID="osdsetup" requires="OsdSetup"><screen module="UserInterfacePositioner" screen="UserInterfacePositioner" /></item>
+				<item entryID="skin_setup" level="0" text="Skin" weight="1"><screen module="SkinSelector" screen="SkinSelector" /></item>
+				<item entryID="osd3dsetup" level="2" text="3D Setup" requires="CanChange3DOsd"><screen module="UserInterfacePositioner" screen="OSD3DSetupScreen" /></item>
+				<item entryID="osdsetup" level="2" text="OSD Position" requires="OsdSetup"><screen module="UserInterfacePositioner" screen="UserInterfacePositioner" /></item>
 			</menu>
-			<!-- Menu / Setup / User Interface / Front Panel -->
-			<menu weight="4" level="0" text="Front panel display" entryID="display_selection" requires="Display">
+			<menu entryID="display_selection" level="0" text="Front Panel Display" weight="4" requires="Display">
 				<id val="display" />
-				<item weight="1" level="0" text="Settings" entryID="display_setup"><setup id="display" /></item>
-				<item weight="2" level="0" text="Skin" entryID="lcd_skin_setup" requires="LCDSKINSetup"><screen module="SkinSelector" screen="LcdSkinSelector" /></item>
+				<item entryID="display_setup" level="0" text="Settings" weight="1"><setup id="display" /></item>
+				<item entryID="lcd_skin_setup" level="0" text="Skin" weight="2"><screen module="SkinSelector" screen="LcdSkinSelector" /></item>
 			</menu>
-			<!-- Menu / Setup / User Interface / LED Display -->
-			<menu weight="5" level="0" text="LED display panel" entryID="leddisplay_selection" requires="DisplayLED">
+			<menu entryID="leddisplay_selection" level="0" text="LED Display Panel" weight="5" requires="DisplayLED">
 				<id val="leddisplay" />
 			</menu>
-			<!-- Menu / Setup / User Interface / Button Setup -->
-			<item weight="6" level="2" text="Button setup" entryID="buttonsetup_setup"><screen module="ButtonSetup" screen="ButtonSetup" /></item>
-			<!-- Menu / Setup / User Interface / Subtitles -->
-			<item weight="7" level="2" entryID="subtitle_setup" text="Subtitles"><setup id="subtitlesetup" /></item>
-			<!-- Menu / Setup / User Interface / Language Selection -->
-			<item weight="8" level="0" text="Language" entryID="language_setup"><screen module="LanguageSelection" /></item>
-			<!-- Menu / Setup / User Interface / Parental Control -->
-			<item weight="9" level="0" text="Parental control" entryID="parental_setup"><screen module="ParentalControlSetup" screen="ParentalControlSetup" /></item>
+			<item entryID="buttonsetup_setup" level="2" text="Button Setup" weight="6"><screen module="ButtonSetup" screen="ButtonSetup" /></item>
+			<item entryID="subtitle_setup" level="2" text="Subtitles" weight="7"><setup id="subtitlesetup" /></item>
+			<item entryID="language_setup" level="0" text="Language" weight="8"><screen module="LanguageSelection" /></item>
+			<item entryID="parental_setup" level="0" text="Parental Control" weight="9"><screen module="ParentalControlSetup" screen="ParentalControlSetup" /></item>
 		</menu>
 
 		<!-- Menu / Setup / Network -->
-		<menu weight="5" text="Network" entryID="network_menu">
+		<menu entryID="network_menu" level="0" text="Network" weight="5">
 			<id val="network" />
-			<!-- Menu / Setup / Network / Device -->
-			<item weight="1" level="0" text="Device" entryID="device_setup"><screen module="NetworkSetup" screen="NetworkAdapterSelection" /></item>
-			<!-- Menu / Setup / Network / Mounts -->
-			<item weight="2" level="1" text="Mounts" entryID="netmounts_setup"><screen module="NetworkSetup" screen="NetworkMountsMenu" /></item>
-			<!-- Menu / Setup / Network / Utilities -->
-			<menu weight="3" level="0" text="Utilities" entryID="services_menu">
+			<item entryID="device_setup" level="0" text="Device" weight="1"><screen module="NetworkSetup" screen="NetworkAdapterSelection" /></item>
+			<item entryID="netmounts_setup" level="1" text="Mounts" weight="2"><screen module="NetworkSetup" screen="NetworkMountsMenu" /></item>
+			<menu entryID="services_menu" level="0" text="Utilities" weight="3">
 				<id val="netservices" />
-				<item level="2" text="AFP" entryID="netafp_setup"><screen module="NetworkSetup" screen="NetworkAfp" /></item>
-				<item level="2" text="FTP" entryID="netftp_setup"><screen module="NetworkSetup" screen="NetworkFtp" /></item>
-				<item level="2" text="Inadyn" entryID="Inadyn_setup"><screen module="NetworkSetup" screen="NetworkInadyn" /></item>
-				<item level="2" text="MiniDLNA" entryID="netdlna_setup"><screen module="NetworkSetup" screen="NetworkMiniDLNA" /></item>
-				<item level="2" text="NFS" entryID="netnfs_setup"><screen module="NetworkSetup" screen="NetworkNfs" /></item>
-				<item level="2" text="OpenVPN" entryID="netvpn_setup"><screen module="NetworkSetup" screen="NetworkOpenvpn" /></item>
-				<item level="2" text="SABnzbd" entryID="netsabnzbd_setup" requires="SABSetup">
+				<item entryID="netafp_setup" level="2" text="AFP"><screen module="NetworkSetup" screen="NetworkAfp" /></item>
+				<item entryID="netftp_setup" level="2" text="FTP"><screen module="NetworkSetup" screen="NetworkFtp" /></item>
+				<item entryID="Inadyn_setup" level="2" text="Inadyn"><screen module="NetworkSetup" screen="NetworkInadyn" /></item>
+				<item entryID="netdlna_setup" level="2" text="MiniDLNA"><screen module="NetworkSetup" screen="NetworkMiniDLNA" /></item>
+				<item entryID="netnfs_setup" level="2" text="NFS"><screen module="NetworkSetup" screen="NetworkNfs" /></item>
+				<item entryID="netvpn_setup" level="2" text="OpenVPN"><screen module="NetworkSetup" screen="NetworkOpenvpn" /></item>
+				<item entryID="netsabnzbd_setup" level="2" text="SABnzbd" requires="SABSetup">
 					<code>
 from Plugins.SystemPlugins.SABnzbd.plugin import SABnzbdSetupScreen
 self.session.open(SABnzbdSetupScreen)
 					</code>
 				</item>
-				<item level="2" text="Samba" entryID="netsmba_setup"><screen module="NetworkSetup" screen="NetworkSamba" /></item>
-				<item level="2" text="Telnet" entryID="nettelnet_setup"><screen module="NetworkSetup" screen="NetworkTelnet" /></item>
-				<item level="2" text="uShare" entryID="netushare_setup"><screen module="NetworkSetup" screen="NetworkuShare" /></item>
+				<item entryID="netsmba_setup" level="2" text="Samba"><screen module="NetworkSetup" screen="NetworkSamba" /></item>
+				<item entryID="nettelnet_setup" level="2" text="Telnet"><screen module="NetworkSetup" screen="NetworkTelnet" /></item>
+				<item entryID="netushare_setup" level="2" text="uShare"><screen module="NetworkSetup" screen="NetworkuShare" /></item>
 			</menu>
-			<!-- Menu / Setup / Network / Password -->
-			<item level="2" text="Password" entryID="password_setup"><screen module="NetworkSetup" screen="NetworkPassword" /></item>
+			<item entryID="password_setup" level="2" text="Password"><screen module="NetworkSetup" screen="NetworkPassword" /></item>
 		</menu>
+
 		<!-- Menu / Setup / Common Interface -->
-		<menu weight="7" text="Common interface" entryID="cicam_setup" requires="CommonInterface">
+		<menu entryID="cicam_setup" level="0" text="Common Interface" weight="7">
 			<id val="cicam" />
-			<item weight="10" level="1" text="Common interface" entryID="ci_setup"><screen module="Ci" screen="CiSelection" /></item>
+			<item entryID="ci_setup" level="1" text="Common Interface" weight="10" requires="CommonInterface"><screen module="Ci" screen="CiSelection" /></item>
 		</menu>
+
 		<!-- Menu / Setup / Softcam -->
-		<menu weight="8" text="Softcam" entryID="cam_setup">
+		<menu entryID="cam_setup" level="0" text="Softcam" weight="8">
 			<id val="cam" />
-			<item weight="1" level="2" text="Settings" entryID="softcam_setup"><setup id="softcamsetup" /></item>
-			<item weight="98" level="2" text="CCcam info" entryID="cccaminfo" requires="CCcamInstalled"><screen module="CCcamInfo" screen="CCcamInfoMain" /></item>
-			<item weight="99" level="2" text="OScam info" entryID="oscaminfo" requires="OScamInstalled"><screen module="OScamInfo" screen="OscamInfoMenu" /></item>
+			<item entryID="softcam_setup" level="2" text="Settings" weight="1"><setup id="softcamsetup" /></item>
+			<item entryID="cccaminfo" level="2" text="CCcam Info" weight="98" requires="CCcamInstalled"><screen module="CCcamInfo" screen="CCcamInfoMain" /></item>
+			<item entryID="oscaminfo" level="2" text="OScam Info" weight="99" requires="OScamInstalled"><screen module="OScamInfo" screen="OscamInfoMenu" /></item>
 		</menu>
+
 		<!-- Menu / Setup / Storage -->
-		<menu weight="9" level="0" text="Storage" entryID="hardisk_selection" requires="Harddisk">
+		<menu entryID="hardisk_selection" level="0" text="Storage" weight="9" requires="Harddisk">
 			<id val="harddisk" />
-			<item level="1" text="Settings" entryID="harddisk_setup"><setup id="harddisk" /></item>
-			<item level="0" text="Initialize devices" entryID="harddisk_init"><screen module="HarddiskSetup" screen="HarddiskSelection" /></item>
-			<item level="0" text="Filesystem check" entryID="harddisk_check"><screen module="HarddiskSetup" screen="HarddiskFsckSelection" /></item>
+			<item entryID="harddisk_setup" level="1" text="Settings"><setup id="harddisk" /></item>
+			<item entryID="harddisk_init" level="0" text="Initialize Devices"><screen module="HarddiskSetup" screen="HarddiskSelection" /></item>
+			<item entryID="harddisk_check" level="0" text="Filesystem Check"><screen module="HarddiskSetup" screen="HarddiskFsckSelection" /></item>
 		</menu>
-		<!-- Menu / Setup / Time Settings -->
-		<item level="0" text="Time" entryID="time_setup"><screen module="Time" screen="Time" /></item>
+
 		<!-- Menu / Setup / Recordings, Playback & Timeshift -->
-		<menu weight="11" level="1" text="Recordings, playback &amp; timeshift" entryID="rec_setup">
+		<menu entryID="rec_setup" level="1" text="Recordings, Playback &amp; Timeshift" weight="11">
 			<id val="rec" />
-				<item weight="10" level="0" text="Timeshift" entryID="timshift_setup"><screen module="Timeshift" screen="TimeshiftSettings" /></item>
-				<item weight="15" level="0" text="Recording &amp; playback" entryID="recording_setup"><screen module="Recordings" screen="RecordingSettings" /></item>
+			<item entryID="recording_setup" level="0" text="Recording &amp; Playback" weight="10"><screen module="Recordings" screen="RecordingSettings" /></item>
+			<item entryID="timshift_setup" level="0" text="Timeshift" weight="15"><screen module="Timeshift" screen="TimeshiftSettings" /></item>
 		</menu>
-		<!-- Menu / Setup / System (OLD SYSTEM ENTRY FOR COMPATIBILITY) -->
-		<menu weight="98" level="0" text="System" entryID="system_selection">
+
+		<!-- Menu / Setup / Time Settings -->
+		<item entryID="time_setup" level="0" text="Time" weight="12"><screen module="Time" screen="Time" /></item>
+
+		<!-- Menu / Setup / System -->
+		<menu entryID="system_selection" level="0" text="System" weight="98">
 			<id val="system" />
-			<!-- Menu / Setup / System / Logs -->
-			<item weight="1" entryID="usage_setup" text="Customize"><setup id="usage" /></item>
-			<menu weight="2" level="2" text="Logs" entryID="logs_setup">
+			<item entryID="usage_setup" level="0" text="Customize" weight="1"><setup id="usage" /></item>
+			<menu entryID="logs_setup" level="2" text="Logs" weight="2">
 				<id val="logs_menu" />
-				<item level="2" text="Settings" entryID="logs_setup"><setup id="logs" /></item>
-				<item level="2" text="Log manager" entryID="logs_man"><screen module="LogManager" screen="LogManager" /></item>
+				<item entryID="logs_setup" level="2" text="Settings"><setup id="logs" /></item>
+				<item entryID="logs_man" level="2" text="Log Manager"><screen module="LogManager" screen="LogManager" /></item>
 			</menu>
-			<!-- Menu / Setup / System / Input Devices -->
-			<item weight="3" level="1" text="Input devices" entryID="input_device_setup"><screen module="InputDeviceSetup" screen="InputDeviceSelection" /></item>
-			<!-- Menu / Setup / System / Keyboard Setup -->
-			<item weight="4" entryID="keyboard_setup" text="Keyboard"><setup id="keyboard" /></item>
-			<!-- Menu / Setup / System / RF Setup -->
-			<item weight="5" level="1" entryID="rfmod_setup" text="Settings" requires="RfModulator"><setup id="RFmod" /></item>
-			<!-- Menu / Setup / System / Factory Reset -->
-			<item weight="99" level="0" text="Factory reset" entryID="factory_reset"><screen module="FactoryReset" screen="FactoryReset" /></item>
-			<item weight="2" level="0" text="Software update" entryID="software_update"><screen module="SoftwareUpdate" screen="UpdatePlugin" /></item>
+			<item entryID="software_update" level="0" text="Software Update" weight="2"><screen module="SoftwareUpdate" screen="UpdatePlugin" /></item>
+			<item entryID="input_device_setup" level="1" text="Input Devices" weight="3"><screen module="InputDeviceSetup" screen="InputDeviceSelection" /></item>
+			<item entryID="keyboard_setup" level="0" text="Keyboard" weight="4"><setup id="keyboard" /></item>
+			<item entryID="rfmod_setup" level="1" text="Settings" weight="5" requires="RfModulator"><setup id="RFmod" /></item>
+			<item entryID="factory_reset" level="0" text="Factory Reset" weight="99"><screen module="FactoryReset" screen="FactoryReset" /></item>
 		</menu>
+
 		<!-- Menu / Setup / HDMI-CEC -->
-		<item weight="99" text="HDMI CEC" entryID="hdmicec" requires="HDMICEC">
+		<item entryID="hdmicec" level="0" text="HDMI CEC" weight="99" requires="HDMICEC">
 			<code>
 from Plugins.SystemPlugins.HdmiCEC.plugin import HdmiCECSetupScreen
 self.session.open(HdmiCECSetupScreen)
@@ -213,41 +201,45 @@ self.session.open(HdmiCECSetupScreen)
 	</menu>
 
 	<!-- Menu / Plugins -->
-	<item weight="2" text="Plugins" entryID="plugin_selection"><screen module="PluginBrowser" screen="PluginBrowser" /></item>
+	<item entryID="plugin_selection" level="0" text="Plugins" weight="2"><screen module="PluginBrowser" screen="PluginBrowser" /></item>
 
 	<!-- Menu / Timers -->
-	<menu weight="5" text="Timers" entryID="timer_menu">
+	<menu entryID="timer_menu" level="0" text="Timers" weight="5">
 		<id val="timermenu" />
-		<item weight="1" level="0" text="Timers" entryID="timer_edit"><screen module="TimerEdit" screen="TimerEditList" /></item>
-		<item weight="100" level="0" text="Cron timers" entryID="crontimer_edit"><screen module="CronTimer" screen="CronTimers" /></item>
-		<item weight="100" level="0" text="Power timers" entryID="powertimer_edit"><screen module="PowerTimerEdit" screen="PowerTimerEditList" /></item>
+		<item entryID="timer_edit" level="0" text="Timers" weight="1"><screen module="TimerEdit" screen="TimerEditList" /></item>
+		<item entryID="crontimer_edit" level="0" text="Cron Timers" weight="100"><screen module="CronTimer" screen="CronTimers" /></item>
+		<item entryID="powertimer_edit" level="0" text="Power Timers" weight="100"><screen module="PowerTimerEdit" screen="PowerTimerEditList" /></item>
 	</menu>
 
 	<!-- Menu / Information -->
-	<menu weight="6" text="Information" entryID="info_screen">
+	<menu entryID="info_screen" level="0" text="Information" weight="6">
 		<id val="information" />
-		<item level="0" text="About" entryID="about_screen"><screen module="About" screen="About" /></item>
-		<item level="0" text="Devices" entryID="device_screen"><screen module="About" screen="Devices" /></item>
-		<item level="0" text="Memory" entryID="memory_screen"><screen module="About" screen="SystemMemoryInfo" /></item>
-		<item level="0" text="Network" entryID="network_screen"><screen module="About" screen="SystemNetworkInfo" /></item>
-		<item level="1" text="Service" entryID="service_info_screen"><screen module="ServiceInfo" screen="ServiceInfo" /></item>
-		<item level="2" text="Streaming clients" entryID="streaming_clients_info_screen"><screen module="StreamingClientsInfo" /></item>
+		<item entryID="about_screen" level="0" text="About"><screen module="About" screen="About" /></item>
+		<item entryID="device_screen" level="0" text="Devices"><screen module="About" screen="Devices" /></item>
+		<item entryID="memory_screen" level="0" text="Memory"><screen module="About" screen="SystemMemoryInfo" /></item>
+		<item entryID="network_screen" level="0" text="Network"><screen module="About" screen="SystemNetworkInfo" /></item>
+		<item entryID="service_info_screen" level="1" text="Service"><screen module="ServiceInfo" screen="ServiceInfo" /></item>
+		<item entryID="streaming_clients_info_screen" level="2" text="Streaming Clients"><screen module="StreamingClientsInfo" /></item>
 	</menu>
 
 	<!-- Menu / VCR Scart -->
-	<item weight="7" text="VCR scart" entryID="scart_switch" conditional="config.usage.show_vcr_scart.value" requires="ScartSwitch"><code>self.session.scart.VCRSbChanged(3)</code></item>
+	<item entryID="scart_switch" level="0" text="VCR Scart" weight="7" conditional="config.usage.show_vcr_scart.value" requires="ScartSwitch">
+		<code>
+self.session.scart.VCRSbChanged(3)
+		</code>
+	</item>
 
 	<!-- Menu / Standby and Restart -->
-	<menu weight="99" text="Standby and Restart" entryID="standby_restart_list">
+	<menu entryID="standby_restart_list" text="Standby &amp; Restart" weight="99">
 		<id val="shutdown" />
-		<item text="Standby" entryID="standby"><screen module="Standby" screen="Standby" /></item>
-		<item text="Restart GUI" entryID="restart_enigma"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
-		<item text="Reboot" entryID="restart"><screen module="Standby" screen="TryQuitMainloop">2</screen></item>
-		<item text="Multiboot Image Selector" entryID="multiboot" requires="canMultiBoot"><screen module="MultiBootSelector" screen="MultiBootSelector">1</screen></item>
-		<item text="H9SDroot" entryID="H9SDswap" requires="HasH9SD"><screen module="H9SDswap" screen="H9SDswap">1</screen></item>
-		<item text="Deep standby" requires="DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
-		<item text="Shut down" requires="!DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
-		<item text="Recovery mode" requires="RecoveryMode" entryID="maintenance_mode"><screen module="Standby" screen="TryQuitMainloop">16</screen></item>
-		<item text="Android mode" requires="AndroidMode" entryID="android_mode"><screen module="Standby" screen="TryQuitMainloop">12</screen></item>
+		<item entryID="standby" level="0" text="Standby"><screen module="Standby" screen="Standby" /></item>
+		<item entryID="restart_enigma" level="0" text="Restart GUI"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
+		<item entryID="restart" level="0" text="Reboot"><screen module="Standby" screen="TryQuitMainloop">2</screen></item>
+		<item entryID="multiboot" level="0" text="MultiBoot Image Selector" requires="canMultiBoot"><screen module="MultiBootSelector" screen="MultiBootSelector">1</screen></item>
+		<item entryID="H9SDswap" level="0" text="H9SDroot" requires="HasH9SD"><screen module="H9SDswap" screen="H9SDswap">1</screen></item>
+		<item entryID="deep_standby" level="0" text="Deep Standby" requires="DeepstandbySupport"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
+		<item entryID="deep_standby" level="0" text="Shut Down" requires="!DeepstandbySupport"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
+		<item entryID="maintenance_mode" level="0" text="Recovery Mode" requires="RecoveryMode"><screen module="Standby" screen="TryQuitMainloop">16</screen></item>
+		<item entryID="android_mode" level="0" text="Android Mode" requires="AndroidMode"><screen module="Standby" screen="TryQuitMainloop">12</screen></item>
 	</menu>
 </menu>

--- a/data/menu.xml
+++ b/data/menu.xml
@@ -27,7 +27,7 @@
 		<menu weight="1" level="0" text="Audio &amp; video" entryID="av_setup">
 			<id val="av" />
 			<item weight="1" text="Settings" entryID="av_setup"><screen module="VideoMode" screen="VideoSetup" /></item>
-			<item level="1" entryID="autolanguage_setup"><setup id="autolanguagesetup" /></item>
+			<item level="1" entryID="autolanguage_setup" text="Automatic Language"><setup id="autolanguagesetup" /></item>
 		</menu>
 
 		<!-- Menu / Setup / Tuners -->
@@ -36,7 +36,7 @@
 			<!-- Menu / Setup / Tuners / Settings -->
 			<item weight="1" text="Tuner setup" entryID="tuner_setup" requires="ClientModeDisabled"><screen module="Satconfig" screen="NimSelection" /></item>
 			<item weight="2" text="Tuner setup" entryID="client_mode" requires="ClientModeEnabled"><screen module="ClientMode" screen="ClientModeScreen" /></item>
-			<item weight="3" entryID="tunermisc_setup"><setup id="tunermisc" /></item>
+			<item weight="3" entryID="tunermisc_setup" text="Miscellaneous"><setup id="tunermisc" /></item>
 			<item weight="20" text="Automatic scan" entryID="auto_scan" conditional="nimmanager.somethingConnected()" requires="ClientModeDisabled"><screen module="ScanSetup" screen="ScanSimple" /></item>
 			<item weight="30" text="Manual scan" entryID="manual_scan" conditional="nimmanager.somethingConnected()" requires="ClientModeDisabled"><screen module="ScanSetup" /></item>
 			<item weight="100" text="Fallback configuration" entryID="fallback_mode" requires="ClientModeDisabled"><screen  module="FallbackTunerSetup" screen="FallbackTunerSetup" /></item>
@@ -45,10 +45,10 @@
 		<!-- Menu / Setup / EPG -->
 		<menu weight="3" text="EPG" entryID="epg_menu">
 			<id val="epg" />
-			<item level="0" entryID="epg_setup"><setup id="epgsettings" /></item>
+			<item level="0" entryID="epg_setup" text="Settings"><setup id="epgsettings" /></item>
 			<menu level="2" text="Load-save-delete" entryID="epgloadsave_menu">
 				<id val="epgloadsave_menu" />
-				<item level="0" entryID="saveepgcache" text="Save EPG">
+				<item level="0" entryID="saveepgcache" text="Save EPG Cache">
 					<code>
 from Components.EpgLoadSave import EpgSaveMsg
 def msgClosed(ret):
@@ -59,7 +59,7 @@ def msgClosed(ret):
 self.session.openWithCallback(msgClosed, EpgSaveMsg)
 					</code>
 				</item>
-				<item level="0" entryID="loadepgcache" text="Load EPG">
+				<item level="0" entryID="loadepgcache" text="Load EPG Cache">
 					<code>
 from Components.EpgLoadSave import EpgLoadMsg
 def msgClosed(ret):
@@ -70,7 +70,7 @@ def msgClosed(ret):
 self.session.openWithCallback(msgClosed, EpgLoadMsg)
 					</code>
 				</item>
-				<item level="0" entryID="deleteepgcache" text="Delete EPG">
+				<item level="0" entryID="deleteepgcache" text="Delete EPG Cache">
 					<code>
 from Components.EpgLoadSave import EpgDeleteMsg
 def msgClosed(ret):
@@ -86,20 +86,20 @@ self.session.openWithCallback(msgClosed, EpgDeleteMsg)
 					</code>
 				</item>
 			</menu>
-			<item level="2" entryID="setup_epgsingle"><setup id="epgsingle" /></item>
-			<item level="2" entryID="setup_epggrid"><setup id="epggrid" /></item>
-			<item level="2" entryID="setup_epginfobarsingle"><setup id="epginfobarsingle" /></item>
-			<item level="2" entryID="setup_epginfobargrid"><setup id="epginfobargrid" /></item>
-			<item level="2" entryID="setup_epgmulti"><setup id="epgmulti" /></item>
+			<item level="2" entryID="setup_epgsingle" text="Single EPG"><setup id="epgsingle" /></item>
+			<item level="2" entryID="setup_epggrid" text="Grid EPG"><setup id="epggrid" /></item>
+			<item level="2" entryID="setup_epginfobarsingle" text="Infobar Single EPG"><setup id="epginfobarsingle" /></item>
+			<item level="2" entryID="setup_epginfobargrid" text="Infobar Grid EPG"><setup id="epginfobargrid" /></item>
+			<item level="2" entryID="setup_epgmulti" text="Multi EPG"><setup id="epgmulti" /></item>
 		</menu>
 
 		<!-- Menu / Setup / User Interface -->
 		<menu weight="4" text="User interface" entryID="osd_setup" requires="OsdMenu">
 			<id val="osd_menu" />
 			<!-- Menu / Setup / User Interface / Settings -->
-			<item weight="1" entryID="user_interface"><setup id="userinterface" /></item>
+			<item weight="1" entryID="user_interface" text="Settings"><setup id="userinterface" /></item>
 			<!-- Menu / Setup / User Interface / Channel Selection settings -->
-			<item weight="2" level="0" entryID="channelselection_setup"><setup id="channelselection" /></item>
+			<item weight="2" level="0" entryID="channelselection_setup" text="Channel Selection"><setup id="channelselection" /></item>
 			<!-- Menu / Setup / User Interface / Skin Setup -->
 			<menu weight="3" level="0" text="Skin setup" entryID="gui_skin" requires="OsdMenu">
 				<id val="skinsetup" />
@@ -120,7 +120,7 @@ self.session.openWithCallback(msgClosed, EpgDeleteMsg)
 			<!-- Menu / Setup / User Interface / Button Setup -->
 			<item weight="6" level="2" text="Button setup" entryID="buttonsetup_setup"><screen module="ButtonSetup" screen="ButtonSetup" /></item>
 			<!-- Menu / Setup / User Interface / Subtitles -->
-			<item weight="7" level="2" entryID="subtitle_setup"><setup id="subtitlesetup" /></item>
+			<item weight="7" level="2" entryID="subtitle_setup" text="Subtitles"><setup id="subtitlesetup" /></item>
 			<!-- Menu / Setup / User Interface / Language Selection -->
 			<item weight="8" level="0" text="Language" entryID="language_setup"><screen module="LanguageSelection" /></item>
 			<!-- Menu / Setup / User Interface / Parental Control -->
@@ -187,7 +187,7 @@ self.session.open(SABnzbdSetupScreen)
 		<menu weight="98" level="0" text="System" entryID="system_selection">
 			<id val="system" />
 			<!-- Menu / Setup / System / Logs -->
-			<item weight="1" entryID="usage_setup"><setup id="usage" /></item>
+			<item weight="1" entryID="usage_setup" text="Customize"><setup id="usage" /></item>
 			<menu weight="2" level="2" text="Logs" entryID="logs_setup">
 				<id val="logs_menu" />
 				<item level="2" text="Settings" entryID="logs_setup"><setup id="logs" /></item>
@@ -198,7 +198,7 @@ self.session.open(SABnzbdSetupScreen)
 			<!-- Menu / Setup / System / Keyboard Setup -->
 			<item weight="4" entryID="keyboard_setup" text="Keyboard"><setup id="keyboard" /></item>
 			<!-- Menu / Setup / System / RF Setup -->
-			<item weight="5" level="1" entryID="rfmod_setup" requires="RfModulator"><setup id="RFmod" /></item>
+			<item weight="5" level="1" entryID="rfmod_setup" text="Settings" requires="RfModulator"><setup id="RFmod" /></item>
 			<!-- Menu / Setup / System / Factory Reset -->
 			<item weight="99" level="0" text="Factory reset" entryID="factory_reset"><screen module="FactoryReset" screen="FactoryReset" /></item>
 			<item weight="2" level="0" text="Software update" entryID="software_update"><screen module="SoftwareUpdate" screen="UpdatePlugin" /></item>

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -1,5 +1,4 @@
 <!--suppress XmlUnboundNsPrefix -->
-<!-- "menuTitle" attribute is optional. If present it will be used as the item title in the menu. It will also be used as the header in setup screens when menu path is enabled. -->
 <setupxml>
 	<setup key="time" title="Time">
 		<item level="0" text="Time zone area" description="Select your time zone area or region.">config.timezone.area</item>
@@ -13,7 +12,7 @@
 	<setup key="avsetup" title="A/V settings">
 		<!-- This is just a placeholder, the Videomode plugin implements this submenu -->
 	</setup>
-	<setup key="usage" title="Customize settings" menuTitle="Customize">
+	<setup key="usage" title="Customize settings">
 		<item level="0" text="Setup mode" description="Choose which level of menu/settings to display. 'Expert' level shows all items.">config.usage.setup_level</item>
 		<item level="0" text="Task warning on shutdown" description="On shutdown/restart warn about any pending jobs being carried out in the background.">config.usage.task_warning</item>
 		<item level="1" text="Enable teletext caching" description="When enabled, teletext pages will be cached, allowing faster access.">config.usage.enable_tt_caching</item>
@@ -23,7 +22,7 @@
 		<item level="2" text="Require authentication for http streams" description="When enabled, authentication is required to watch http streams.">config.streaming.authentication</item>
 		<item level="2" text="Wake On LAN" description="When enabled the set top box is able to wakeup on LAN" requires="WakeOnLAN">config.usage.wakeOnLAN</item>
 	</setup>
-	<setup key="tunermisc" title="Tuner miscellaneous" menuTitle="Miscellaneous" showOpenWebIF="1">
+	<setup key="tunermisc" title="Tuner miscellaneous" showOpenWebIF="1">
 		<item level="1" text="12V output" description="12V output." requires="12V_Output">config.usage.output_12V</item>
 		<item level="2" text="Preferred tuner" description="Configure which tuner will be preferred, when more than one tuner is available. If set to 'auto' the system will give priority to the tuner having the lowest number of channels/satellites.">config.usage.frontend_priority</item>
 		<item level="2" text="Preferred tuner DVB-S" description="When enabled, this setting has more weight than 'Preferred tuner'." requires="DVB-S_priority_tuner_available">config.usage.frontend_priority_dvbs</item>
@@ -41,7 +40,7 @@
 		<item level="2" text="Ignore DVB-T namespace sub network" description="On valid ONIDs, ignore frequency sub network part">config.usage.subnetwork_terrestrial</item>
 		<item level="2" text="Alternative services tuner priority" description="Configure which tuner type will be preferred, when the same service is available on different types of tuners.">config.usage.alternatives_priority</item>
 	</setup>
-	<setup key="userinterface" title="GUI settings" menuTitle="Settings">
+	<setup key="userinterface" title="GUI settings">
 		<item level="0" text="1st Infobar timeout" description="Set the time delay before hiding the infobar.">config.usage.infobar_timeout</item>
 		<item level="2" text="Show second infobar" description="Configure whether (and for how long) a second infobar will be shown when OK is pressed twice. The second infobar contains additional information about the current channel.">config.usage.show_second_infobar</item>
 		<item level="0" text="Enable infobar fade-out" description="Fade the infobar when hiding">config.usage.show_infobar_do_dimming</item>
@@ -96,7 +95,7 @@
 		<item level="1" text="Jump first press in channel selection" description="This option allows you to choose what the first button press jumps to in channel list screen, (so pressing '2' jumps to 'A' or '2' first), when 'Quick Actions' preset actions are perfomed. ">config.usage.show_channel_jump_in_servicelist</item>
 		<item level="0" text="Show event-progress in channel selection" description="Set the type of the progress indication in the channel selection screen.">config.usage.show_event_progress_in_servicelist</item>
 		<item level="0" text="Show channel numbers in channel selection" description="When enabled, show channel numbers in the channel selection screen.">config.usage.show_channel_numbers_in_servicelist</item>
-		<item level="2" text="Show two lines per entry" description="Show the service information on two lines in the channel selection screen. You can choose between the current event description below the channel name, or the current event description next to the channel name, and the next event description on the second line.">config.usage.servicelist_twolines</item>
+		<item level="2" text="Show two lines per entry" description="Show service name and event description above and below each other instead of side by side.">config.usage.servicelist_twolines</item>
 		<item level="1" text="Show crypto icons" description="Configure if and how crypto icons will be shown in the channel selection list.">config.usage.crypto_icon_mode</item>
 		<item level="1" text="Show service type icons" description="Configure if and how service type icons will be shown.">config.usage.servicetype_icon_mode</item>
 		<item level="1" text="Show record indicator" description="Configure if and how the record indicator will be shown in the channel selection list.">config.usage.record_indicator_mode</item>
@@ -112,7 +111,7 @@
 		<item level="1" text="Zap mode" requires="ZapMode" description="Setup how to control the channel changing.">config.misc.zapmode</item>
 		<item level="2" text="Number of digits in channel number" description="This allows you to set the number of digits you can input when selecting channels using number input.">config.usage.maxchannelnumlen</item>
 	</setup>
-	<setup key="epgsettings" title="EPG settings" menuTitle="Settings">
+	<setup key="epgsettings" title="EPG settings">
 		<item level="0" text="EPG button action" description="Choose what will be displayed when the 'EPG' button is pressed.">config.usage.defaultEPGType</item>
 		<item level="0" text="INFO button action" description="Choose what will be displayed when the 'INFO' button is pressed.">config.usage.defaultINFOType</item>
 		<item level="2" text="EPG location" description="Choose the location where the EPG data will be stored when the %s %s is shut down. The location must be available at boot time.">config.misc.epgcachepath</item>
@@ -210,10 +209,10 @@
 		<item level="2" text="Offline decode delay (ms)" description="Configure the offline decoding delay (in milliseconds). The configured delay is observed at each control word parity change.">config.recording.offline_decode_delay</item>
 		<item level="2" text="Default recording type" description="Descramble &amp; record ECM' gives the option to descramble afterwards if descrambling on recording failed. 'Don't descramble, record ECM' save a scramble recording that can be descrambled on playback. 'Normal' means descramble the recording and don't record ECM.">config.recording.ecm_data</item>
 	</setup>
-	<setup key="harddisk" title="HDD settings" menuTitle="Settings">
+	<setup key="harddisk" title="HDD settings">
 		<item level="0" text="Hard disk standby after" description="Configure duration of inactivity before the hard disk drive goes to standby">config.usage.hdd_standby</item>
 	</setup>
-	<setup key="network" title="Network settings" menuTitle="Settings">
+	<setup key="network" title="Network settings">
 		<item text="Use DHCP" description="When enabled, use DHCP for the IP configuration.">config.network.dhcp</item>
 		<item text="IP address" description="Configure the IP address.">config.network.ip</item>
 		<item text="Netmask" description="Configure the netmask.">config.network.netmask</item>
@@ -221,7 +220,7 @@
 		<item text="Nameserver" description="Configure the nameserver (DNS).">config.network.dns</item>
 		<item text="Activate network settings" description="Activate the configured network settings.">config.network.activate</item>
 	</setup>
-	<setup key="RFmod" title="RF output settings" menuTitle="Settings">
+	<setup key="RFmod" title="RF output settings">
 		<item level="1" text="Modulator">config.rfmod.enable</item>
 		<item level="2" text="Test mode">config.rfmod.test</item>
 		<item level="2" text="Sound">config.rfmod.sound</item>
@@ -229,10 +228,10 @@
 		<item level="1" text="Channel">config.rfmod.channel</item>
 		<item level="1" text="Finetune">config.rfmod.finetune</item>
 	</setup>
-	<setup key="keyboard" title="Keyboard settings" menuTitle="Settings">
+	<setup key="keyboard" title="Keyboard settings">
 		<item level="0" text="Keyboard map">config.keyboard.keymap</item>
 	</setup>
-	<setup key="display" title="Front panel settings" menuTitle="Settings" requires="FrontpanelDisplay">
+	<setup key="display" title="Front panel settings" requires="FrontpanelDisplay">
 		<item level="0" text="Use separate Picon pack for Front Display" description="Use piconlcd directory for picons on color LCD">config.lcd.picon_pack</item>
 		<item level="0" text="Show MiniTV in the Front Display" description="You can Display MiniTV with or without OSD Menu" requires="LCDMiniTV">config.lcd.minitvmode</item>
 		<item level="0" text="Show PIP in the Front Display" description="You can Display PIP with or without OSD Menu" requires="LCDMiniTVPiP">config.lcd.minitvpipmode</item>
@@ -283,18 +282,18 @@
 		<item text="Latitude" description="Configure the latitude of your location.">config.sat.diseqcb</item>
 		<item text="Use power measurement" description="When enabled, measure power consumption to detect when the rotor stops turning (when supported by the tuner)." >config.sat.diseqcc</item>
 	</setup>
-	<setup key="softwareupdate" title="Software update settings" menuTitle="Settings">
+	<setup key="softwareupdate" title="Software update settings">
 		<item level="1" text="Background check" description="Perform an online update check in the background">config.softwareupdate.check</item>
 		<item level="1" text="Check every (hours)" description="Setup the interval (in hours) to check for online updates." requires="config.softwareupdate.check">config.softwareupdate.checktimer</item>
 		<item level="1" text="Allow unstable (experimental) updates" description="When enabled the online checker will also check for experimental versions">config.softwareupdate.updatebeta</item>
 		<item level="1" text="Automatic settings backup" description="Perform a settings backup before updating.">config.softwareupdate.autosettingsbackup</item>
 		<item level="1" text="Automatic image backup" description="Perform a complete image backup before updating.">config.softwareupdate.autoimagebackup</item>
 	</setup>
-	<setup key="softcamsetup" title="Softcam settings" menuTitle="Settings">
+	<setup key="softcamsetup" title="Softcam settings">
 		<item level="2" text="Show CCcam Info in extensions?" description="Allows you to show/hide CCcam Info in extensions (blue button).">config.cccaminfo.showInExtensions</item>
 		<item level="2" text="Show OScam Info in extensions?" description="Allows you to show/hide OScam Info in extensions (blue button).">config.oscaminfo.showInExtensions</item>
 	</setup>
-	<setup key="logs" title="Logs settings" menuTitle="Settings">
+	<setup key="logs" title="Logs settings">
 		<item level="2" text="Logs folder location" description="Choose the location for crash and debug logs folder.">config.crash.debug_path</item>
 		<item level="2" text="Enable debug logs *" description="Allows you to enable the debug logs. They contain very detailed information about everything the system does. Reboot required to enable this!">config.crash.enabledebug</item>
 		<item level="2" text="Limit debug log size (MB)" description="Allows you to set the maximum size (MB) of the individual debug logs. When that size is reached, the log file will be truncated to the maximum size every 60 minutes.">config.crash.debugloglimit</item>
@@ -466,7 +465,7 @@
 		<item level="2" text="Blue button (short)" description="Set to what you want the button to do.">config.epgselection.grid.btn_blue</item>
 		<item level="2" text="Blue button (long)" description="Set to what you want the button to do.">config.epgselection.grid.btn_bluelong</item>
 	</setup>
-	<setup key="pluginbrowsersetup" title="Plugin browser settings" menuTitle="Settings">
+	<setup key="pluginbrowsersetup" title="Plugin browser settings">
 		<item level="2" text="Show translation packages" description="If set to 'yes' it will show the 'PO' packages in browser.">config.pluginbrowser.po</item>
 		<item level="2" text="Show source packages" description="If set to 'yes' it will show the 'SRC' packages in browser.">config.pluginbrowser.src</item>
 	</setup>

--- a/doc/SETUP
+++ b/doc/SETUP
@@ -2,7 +2,9 @@ Standardised and Uniform Setup Screens in Enigma2
 -------------------------------------------------
 
 Written by IanSav -  2-Apr-2018
-Updated by IanSav - 26-Sep-2020
+Updated by IanSav - 11-Jul-2020
+Updated by IanSav - 12-Sep-2020  (Thanks to Prl for suggestions.)
+Updated by IanSav -  3-Oct-2020
 
 
 INTRODUCTION:
@@ -18,7 +20,7 @@ interchangeably.
 Standard variable names are documented, together with code and skin coding 
 conventions to assist in creating code that works more universally, with 
 additional benefits from improved Setup screen load performance and reduction 
-in merge issues between images.
+in merge issues between Enigma2 images.
 
 Lastly, the document explains the operation and features of the refactored 
 Setup screen interface ("Screen/Setup.py").
@@ -48,42 +50,35 @@ Significant changes, in no particular order, are:
 	This change also means that the GUI no longer has to be restarted to 
 	allow changes to "setup.xml" to be processed by OpenPLi.
 
-2)	All setup screen titles are also extracted and cached to reduce 
-	screen building time.  This code uses a derivative of the OpenViX 
-	"titleshort" attribute here known as "menuTitle" to allow 
-	"Screens/Menu.py" based menus to have alternate title text.  This 
-	change improves "Screens/Menu.py" screen load times for "Setup" 
-	based screens.
+2)	Optimise, improve and enhance generation of Setup screen item lists.  
+	This change allows the list to be processed once for display rather 
+	than the two or three cycles in some previous versions.
 
-3)	Optimise, improve and enhance generation of Setup screen item lists.  
-	Thange allows the list to be processed 	once for display rather than 
-	the two or three cycles in some previous versions.
+3)	Create a log entry if the Setup screen has no valid entries.
 
-4)	Create a log entry if the Setup screen has no valid entries.
-
-5)	Remove remnants of the setup.xml "separation" attribute directive.  
+4)	Remove remnants of the setup.xml "separation" attribute directive.  
 	This feature is now offered via the skin parameter 
 	"ConfigListSeperator".
 
-6)	When enabled, always obey Setup screen sort setting.
+5)	When enabled, always obey Setup screen sort setting.
 
-7)	If "%s %s" is found in an item's "text" or "description" attribute 
+6)	If "%s %s" is found in an item's "text" or "description" attribute 
 	then replace it with the current box machine brand and model name.
 
-8)	Move the description code from the "SetupSummary" class into the main 
+7)	Move the description code from the "SetupSummary" class into the main 
 	"Setup" class where it is used.
 
-9) 	For OpenPLi add footnote support.  If the last character of an entry 
+8) 	For OpenPLi add footnote support.  If the last character of an entry 
 	item is an "*" then when this item is currently selected by the user 
 	a footnote message will appear to advise the user that a restart 
 	will be required if this item is changed.
 
-10)	Add an option to provide "Setup" screen image based on matching the 
-	setup "key" attribute with an image defined in a new "<setups>" 
-	block in the skin.  This code is conditional on having compatible 
+9)	Add an option to provide "Setup" screen graphic based on matching the 
+	setup "key" attribute with a graphic defined in a new "<setups>" 
+	element in the skin.  This code is conditional on having compatible 
 	changes in "skin.py".
 
-11)	Enable the HELP button to allow users to obtain help while using any 
+10)	Enable the HELP button to allow users to obtain help while using any 
 	"Screens/Setup.py" based screen.  To be fully operational these 
 	changes also need to be accompanied by appropriate changes to 
 	"Components/ConfigList.py".
@@ -92,7 +87,7 @@ Significant changes, in no particular order, are:
 	and associated code should be removed from "Screens/Setup.py" and 
 	integrated into the ActionMap in "Components/ConfigList.py".
 
-12)	The "setup_key" skin facility appears to be unused.  The name has 
+11)	The "setup_key" skin facility appears to be unused.  The name has 
 	been changed to "Setupkey" to better match existing skin names.  
 	This option allows skin designers to create custom "Setup" based 
 	screens.
@@ -104,10 +99,19 @@ Significant changes, in no particular order, are:
 	screen, then try for a "Setupkey" screen and finally use the 
 	standard "Setup" screen.
 
-13)	Perform a PEP8 clean-up of the code.
+12)	Perform a PEP8 clean-up of the code.
 
-14)	Reorganise the imports and code blocks to improve readability of the 
+13)	Reorganise the imports and code blocks to improve readability of the 
 	refactored code.
+
+14)	Logic functionality has been added to the setup XML file.  The 
+	addition of "if", "elif" and "else" elements allow for "item" 
+	elements to be selected for inclusion or exclusion from any setup 
+	based screen.
+
+15)	The syntax consistency of the "if", "elif" and "item" elements is
+	now checked when the setup XML file is loaded.  Issues are reported 
+	in the log file.
 
 
 STRUCTURE OF "setup.xml" FILES:
@@ -135,10 +139,12 @@ Syntax:
 
 The "setupxml" tag defines that the file is a setup configuration file. The 
 "setupxml" tag has no attributes and should contain a list of one or more 
-"setup" tag blocks. Each of the "setup" tag blocks should contain a list of 
-one or more "item" blocks.  Each of the "item" tag blocks must contain a 
-configuration element that has been defined in "Components/UsageConfig.py" 
-or elsewhere.
+"setup" tag elements. Each of the "setup" tag elements should contain a list 
+of one or more "item" or "if" elements.  Each "item" tag element must contain 
+a configuration element that has been defined in "Components/UsageConfig.py" 
+or elsewhere.  Each "if" tag element should contain logic attributes "level", 
+"conditional" or "requires" to allow evaluation as to whether or not that 
+element's content will be used for the Setup screen.
 
 Each of the "setup" tags can have the following attributes:
 
@@ -154,11 +160,6 @@ Each of the "setup" tags can have the following attributes:
 					text used for the heading or title of 
 					this setup screen.
 
-	"menuTitle"	Optional	This attribute is the title that can 
-					be used as an alternative for the 
-					"title" in menus of Setup screen 
-					items.
-
 	"showOpenWebIF"	Optional	This attribute is used to signal that 
 					this Setup screen should be made 
 					available in OpenWebif.
@@ -166,7 +167,14 @@ Each of the "setup" tags can have the following attributes:
 	"requires"	Optional	This attribute is used to test is the 
 					nominated requirements have been met 
 					to enable the activation and use of 
-					this Setup screen.
+					this Setup screen.  The "requires" 
+					attribute value can be either the 
+					name of a config variable without 
+					the ".value" attribute, or the name 
+					of a SystemInfo entry.  If the first 
+					character of the attribute argument 
+					is "!" then the argument logic is 
+					inverted.
 
 	"skin"		Optional	This attribute is used to specify an 
 					override screen name defined in the 
@@ -184,7 +192,15 @@ Each of the "item" tags can have the following attributes:
 					that is displayed to the user when 
 					activating this Setup screen.
 
-	"level"		Recommended	The list of items that may be 
+	"description"	Recommended	This attribute is the help prompt or 
+					information that can, and should, be 
+					used to offer guidance to users in 
+					when and how to set the associated 
+					configuration option.  If this is 
+					omitted no assistance or information 
+					will be offered to users.
+
+	"level"		Optional	The list of items that may be 
 					displayed in any Setup screen is 
 					dynamic. This attribute determines 
 					the user interface setup mode or 
@@ -197,18 +213,19 @@ Each of the "item" tags can have the following attributes:
 				Level=2 -> Expert
 				Level=9 -> Deactivate this entry
 
-	"description"	Recommended	This attribute is the help prompt or 
-					information that can, and should, be 
-					used to offer guidance to users in 
-					when and how to set the associated 
-					configuration option.  If this is 
-					omitted no assistance or information 
-					will be offered to users.
-
 	"conditional"	Optional	This attribute allows for programmed 
 					logic to decide is this item is 
 					eligible for display in the Setup 
-					screen.
+					screen.  The "conditional" attribute 
+					value is a Python expression that 
+					must evaluate to a value that can be 
+					converted to a Boolean.  It is 
+					evaluated in the context of a Setup 
+					class instance, and in the expression 
+					self refers to that instance (which 
+					is mainly useful for classes that 
+					derive from Setup, like 
+					MovieBrowserConfiguration).
 
 	"requires"	Optional	This attribute allows for "SystemInfo" 
 					or "config" variables to be used to 
@@ -249,8 +266,8 @@ by the encompassing item tag.
 				of the "Setup" screen.
 
 	setupimage		This variable uses a name="setupimage" 
-				widget that provides an image to represent 
-				the "Setup" screen being displayed.
+				widget that provides a graphic image to 
+				represent the "Setup" screen being displayed.
 
 	config			This variable uses a name="config" widget 
 				that provides the list of available "Setup" 
@@ -351,8 +368,8 @@ SAMPLE "Setup" SCREEN:
 	</screen>
 
 
-SKIN "Setups" SUPPORT BLOCK:
-============================
+SKIN "Setups" SUPPORT ELEMENT:
+==============================
 
 Syntax:
 
@@ -361,24 +378,25 @@ Syntax:
 		<setup key="sample1" image="setup_key.png" />
 	</setups>
 
-This block is optional but if defined allows a skin designer to associate 
-an image with any "Screens/Setup.py" based screen.  The "setups" tag has no 
-attributes and contains a list of "setup" tags.
+This element is optional but if defined allows a skin designer to associate 
+a graphical image with any "Screens/Setup.py" based screen.  The "setups" 
+tag element has no attributes and contains a list of "setup" tag elements.
 
-Each "setup" tag must contain two attributes:
+Each "setup" tag element must contain two attributes:
 
 	key	This attribute is the value of the key attribute from a 
 		setup.xml file.  If the keys match then this entry defines 
-		an image that is to be used when the nominated Setup 
-		screen is displayed.
+		a graphical image that is to be used when the nominated 
+		Setup screen is displayed.
 
-	image	This attribute is the pathname of the image that is to be 
-		associated with the Setup screen identified by the "key" 
-		attribute.
+	image	This attribute is the pathname of the graphical image that 
+		is to be associated with the Setup screen identified by the 
+		"key" attribute.
 
 There is a special "key" attribute with the name "default".  This entry, 
-if defined, assigns a default image to be used in ALL "Screens/Setup.py" 
-screens that do not have a specifically assigned image.
+if defined, assigns a default graphical image to be used in ALL 
+"Screens/Setup.py" screens that do not have a specifically assigned 
+image.
 
 
 CONCLUSION:

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -16,7 +16,7 @@ from enigma import eTimer
 
 import xml.etree.cElementTree
 
-from Screens.Setup import Setup, getSetupTitle
+from Screens.Setup import Setup
 
 # read the menu
 file = open(resolveFilename(SCOPE_SKIN, 'menu.xml'), 'r')
@@ -139,7 +139,9 @@ class Menu(Screen, HelpableScreen, ProtectedScreen):
 		conditional = node.get("conditional")
 		if conditional and not eval(conditional):
 			return
-		item_text = node.get("text", "").encode("UTF-8")
+		item_text = node.get("text", "* Undefined *").encode("UTF-8")
+		if item_text:
+			item_text = _(item_text)
 		entryID = node.get("entryID", "undefined")
 		weight = node.get("weight", 50)
 		for x in node:
@@ -161,7 +163,7 @@ class Menu(Screen, HelpableScreen, ProtectedScreen):
 				args = x.text or ""
 				screen += ", " + args
 
-				destList.append((_(item_text or "??"), boundFunction(self.runScreen, (module, screen)), entryID, weight))
+				destList.append((item_text, boundFunction(self.runScreen, (module, screen)), entryID, weight))
 				return
 			elif x.tag == 'plugin':
 				extensions = x.get("extensions")
@@ -188,17 +190,13 @@ class Menu(Screen, HelpableScreen, ProtectedScreen):
 				args = x.text or ""
 				screen += ", " + args
 
-				destList.append((_(item_text or "??"), boundFunction(self.runScreen, (module, screen)), entryID, weight))
+				destList.append((item_text, boundFunction(self.runScreen, (module, screen)), entryID, weight))
 				return
 			elif x.tag == 'code':
-				destList.append((_(item_text or "??"), boundFunction(self.execText, x.text), entryID, weight))
+				destList.append((item_text, boundFunction(self.execText, x.text), entryID, weight))
 				return
 			elif x.tag == 'setup':
 				id = x.get("id")
-				if item_text == "":
-					item_text = _(getSetupTitle(id))
-				else:
-					item_text = _(item_text)
 				destList.append((item_text, boundFunction(self.openSetup, id), entryID, weight))
 				return
 		destList.append((item_text, self.nothing, entryID, weight))

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -17,7 +17,6 @@ from Tools.LoadPixmap import LoadPixmap
 
 domSetups = {}
 setupModTimes = {}
-setupTitles = {}
 
 
 class Setup(ConfigListScreen, Screen, HelpableScreen):
@@ -76,10 +75,7 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 				skin = setup.get("skin", None)
 				if skin and skin != "":
 					self.skinName.insert(0, skin)
-				if config.usage.showScreenPath.value in ("large", "small") and "menuTitle" in setup:
-					title = setup.get("menuTitle", None).encode("UTF-8", errors="ignore")
-				else:
-					title = setup.get("title", None).encode("UTF-8", errors="ignore")
+				title = setup.get("title", None).encode("UTF-8", errors="ignore")
 				# If this break is executed then there can only be one setup tag with this key.
 				# This may not be appropriate if conditional setup blocks become available.
 				break
@@ -274,7 +270,7 @@ def setupDom(setup=None, plugin=None):
 
 	setupFileDom = xml.etree.cElementTree.fromstring("<setupxml></setupxml>")
 	setupFile = resolveFilename(SCOPE_PLUGINS, pathJoin(plugin, "setup.xml")) if plugin else resolveFilename(SCOPE_SKIN, "setup.xml")
-	global domSetups, setupModTimes, setupTitles
+	global domSetups, setupModTimes
 	try:
 		modTime = getmtime(setupFile)
 	except (IOError, OSError) as err:
@@ -283,8 +279,6 @@ def setupDom(setup=None, plugin=None):
 			del domSetups[setupFile]
 		if setupFile in setupModTimes:
 			del setupModTimes[setupFile]
-		if setupFile in setupTitles:
-			del setupTitles[setupFile]
 		return setupFileDom
 	cached = setupFile in domSetups and setupFile in setupModTimes and setupModTimes[setupFile] == modTime
 	print("[Setup] XML%s setup file '%s', using element '%s'%s." % (" cached" if cached else "", setupFile, setup, " from plugin '%s'" % plugin if plugin else ""))
@@ -295,8 +289,6 @@ def setupDom(setup=None, plugin=None):
 			del domSetups[setupFile]
 		if setupFile in setupModTimes:
 			del setupModTimes[setupFile]
-		if setupFile in setupTitles:
-			del setupTitles[setupFile]
 		with open(setupFile, "r") as fd:  # This open gets around a possible file handle leak in Python's XML parser.
 			try:
 				fileDom = xml.etree.cElementTree.parse(fd).getroot()
@@ -304,20 +296,14 @@ def setupDom(setup=None, plugin=None):
 				setupFileDom = fileDom
 				domSetups[setupFile] = setupFileDom
 				setupModTimes[setupFile] = modTime
-				setupTitles[setupFile] = {}
 				for setup in setupFileDom.findall("setup"):
 					key = setup.get("key")
 					if key:  # If there is no key then this element is useless and can be skipped!
-						if key in setupTitles[setupFile]:
-							print("[Setup] Warning: Setup key '%s' has been redefined!" % key)
-						title = setup.get("menuTitle", "").encode("UTF-8", errors="ignore")
+						title = setup.get("title", "").encode("UTF-8", errors="ignore")
 						if title == "":
-							title = setup.get("title", "").encode("UTF-8", errors="ignore")
-							if title == "":
-								print("[Setup] Error: Setup key '%s' title is missing or blank!" % key)
-								title = "** Setup error: '%s' title is missing or blank!" % key
-						setupTitles[setupFile][key] = _(title)
-						# print("[Setup] DEBUG: XML setup load: key='%s', title='%s', menuTitle='%s', translated title='%s'" % (key, setup.get("title", "").encode("UTF-8", errors="ignore"), setup.get("menuTitle", "").encode("UTF-8", errors="ignore"), setupTitles[key]))
+							print("[Setup] Error: Setup key '%s' title is missing or blank!" % key)
+							title = "** Setup error: '%s' title is missing or blank!" % key
+						# print("[Setup] DEBUG: XML setup load: key='%s', title='%s'." % (key, setup.get("title", "").encode("UTF-8", errors="ignore")))
 			except xml.etree.cElementTree.ParseError as err:
 				fd.seek(0)
 				content = fd.readlines()
@@ -355,15 +341,3 @@ def getConfigMenuItem(configElement):
 		if item.text == configElement:
 			return _(item.attrib["text"]), eval(configElement)
 	return "", None
-
-# Only used in Menu screen...
-#
-def getSetupTitle(key):
-	setupDom()  # Load or check for an updated setup.xml file.
-	if not isinstance(key, str):
-		key = str(key)
-	title = setupTitles[resolveFilename(SCOPE_SKIN, "setup.xml")].get(key, None)
-	if title is None:
-		print("[Setup] Error: Setup key '%s' not found in setup file!" % key)
-		title = _("** Setup error: '%s' section not found! **") % key
-	return title


### PR DESCRIPTION
[menu.xml] Correct indentation and spacing
- This change corrects the indentation of all the XML elements and comments.  Self closing tags now have a space.

[menu.xml] Add title text for all entries
- This change adds title text for all entries that didn't have a title (text) attribute.

[menu.xml] Sort and complete attributes
- This change sorts the element attributes to make it easier to find and maintain the attribute data.  This change also adds the level attribute to all elements that did not have one (this mirrors the layout of the setup.xml file).

[setup.xml] Remove the menuTitle attribute
- The menu.xml file now has a complete set of title (text) attributes so this data is no longer required.

[Menu.py] Remove dependence of setup titles
- This change uses the more complete menu.xml file such that the Setup.py collection and caching of menu titles is no longer required.
- Simplify the menu title translation code.

[Setup.py] Remove menu title processing
- With a more complete menu.xml this code no longer needs to support or supply data to Menu.py.

[SETUP] Update Setup documentation
