### PR TITLE
Wizard & time config list fixups

### DIFF
--- a/lib/python/Screens/Time.py
+++ b/lib/python/Screens/Time.py
@@ -51,7 +51,4 @@ class Time(Setup):
 			self.setFootnote(_("Geolocation has been used to set the time zone."))
 
 	def yellow(self):  # Invoked from the Wizard.
-		self.selectionChanged()
 		self.useGeolocation()
-		self["config"].l.invalidate()
-		config.timezone.save()

--- a/lib/python/Screens/Wizard.py
+++ b/lib/python/Screens/Wizard.py
@@ -584,7 +584,7 @@ class Wizard(Screen):
 				if self.wizard[self.currStep]["config"]["type"] == "dynamic":
 					print "[Wizard] config type is dynamic"
 					self["config"].instance.setZPosition(2)
-					self["config"].l.setList(eval("self." + self.wizard[self.currStep]["config"]["source"])())
+					self["config"].list = eval("self." + self.wizard[self.currStep]["config"]["source"])()
 				elif self.wizard[self.currStep]["config"]["screen"] is not None:
 					if self.wizard[self.currStep]["config"]["type"] == "standalone":
 						print "[Wizard] Type is standalone"
@@ -599,8 +599,13 @@ class Wizard(Screen):
 								self.configInstance = self.session.instantiateDialog(self.wizard[self.currStep]["config"]["screen"], eval(self.wizard[self.currStep]["config"]["args"]))
 							except:
 								self.configInstance = self.session.instantiateDialog(self.wizard[self.currStep]["config"]["screen"], self.wizard[self.currStep]["config"]["args"])
-						self.configInstance.setAnimationMode(0)
-						self["config"].l.setList(self.configInstance["config"].list)
+						# When run this way, the setup screen is instantiated, not shown.
+						# The contents of self.configInstance["config"].list are copied
+						# into self["config"], the contents of
+						# self.configInstance["config"] are cleared (as if by a close()),
+						# and self["config"] is assigned to
+						# self.configInstance["config"]
+						self["config"].list = self.configInstance["config"].list
 						callbacks = self.configInstance["config"].onSelectionChanged
 						self.configInstance["config"].destroy()
 						print "[Wizard] clearConfigList", self.configInstance["config"], self["config"]
@@ -608,7 +613,7 @@ class Wizard(Screen):
 						self.configInstance["config"].onSelectionChanged = callbacks
 						print "[Wizard] clearConfigList", self.configInstance["config"], self["config"]
 				else:
-					self["config"].l.setList([])
+					self["config"].list = []
 					self.handleInputHelpers()
 
 


### PR DESCRIPTION
Fix bug in Wizard that could cause the Wizard's (and setup screen's) config list and the list in the config lists's instance to get out of step.

This allowed a simplification of Time.yellow()