### PR TITLE
[Renderer.Pixmap] Stop CHANGED_CLEAR clearing the pixmap inappropriately

### DIFF
--- a/lib/python/Components/Renderer/Pixmap.py
+++ b/lib/python/Components/Renderer/Pixmap.py
@@ -13,9 +13,8 @@ class Pixmap(Renderer):
 		self.changed((self.CHANGED_DEFAULT,))
 
 	def changed(self, what):
-		if what[0] != self.CHANGED_CLEAR:
-			if self.source and hasattr(self.source, "pixmap"):
-				if self.instance:
-					self.instance.setPixmap(self.source.pixmap)
-		elif self.instance:
-			self.instance.setPixmap(None)
+		if self.source and hasattr(self.source, "pixmap") and self.instance:
+			if what[0] == self.CHANGED_CLEAR:
+				self.instance.setPixmap(None)
+			else:
+				self.instance.setPixmap(self.source.pixmap)


### PR DESCRIPTION
This corrects an earlier fix to Renderer.Pixmap in commit 414da5c.

The instance pixmap should only be cleared on CHANGE_CLEAR if the
pixmap is being taked from renderer.source's pixmap atrtribute (when
it has one).

This fixes problems seen in the display of the tuner type icon in
the infobar in the iSkin-* and Q-FHD_BLACK infobar skins, where the
icon would be displayed after a reboot (or GUI restart), but disappear
after the first channel change.